### PR TITLE
Enhance cross-platform hotkey setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ iwr -useb https://example.com/install.ps1 | iex
 ```
 
 After installation, restart your terminal or log out/in if prompted.
+Detailed hotkey setup instructions for each platform are available in
+[docs/HOTKEYS.md](docs/HOTKEYS.md).
 
 ## 4. Try the hotkey
 

--- a/docs/HOTKEYS.md
+++ b/docs/HOTKEYS.md
@@ -1,0 +1,41 @@
+# Global Hotkey Setup
+
+This project provides platform-specific scripts for launching `prompt-automation` with a keyboard shortcut.
+The default key combination is **Ctrl+Shift+J**.
+
+## Windows
+1. Run `scripts/install.ps1` from PowerShell. The script installs dependencies, checks for AutoHotkey v2, and copies `windows.ahk` to your Startup folder.
+2. Verify registration with:
+   ```powershell
+   Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup" | Where-Object Name -eq 'prompt-automation.ahk'
+   ```
+3. To unregister or change the hotkey, remove or edit `prompt-automation.ahk` from that folder and log out.
+
+## macOS
+1. Open `src/prompt_automation/hotkey/macos.applescript` with Automator and save it as an **Application**.
+2. Assign a keyboard shortcut under **System Preferences › Keyboard › Shortcuts › App Shortcuts**.
+3. Add the generated `.app` bundle to login items:
+   ```bash
+   osascript -e 'tell application "System Events" to make login item at end with properties {path:"/path/to/prompt-automation.app", hidden:false}'
+   ```
+4. Remove the login item with:
+   ```bash
+   osascript -e 'tell application "System Events" to delete login item "prompt-automation"'
+   ```
+
+## Linux / WSL2
+1. Ensure [Espanso](https://espanso.org) is installed.
+2. Copy `src/prompt_automation/hotkey/linux.yaml` to `~/.config/espanso/match/prompt-automation.yml` and run `espanso restart`.
+3. If Espanso is unavailable, create `~/.config/autostart/prompt-automation.desktop`:
+   ```ini
+   [Desktop Entry]
+   Type=Application
+   Exec=prompt-automation
+   Hidden=false
+   NoDisplay=false
+   X-GNOME-Autostart-enabled=true
+   Name=prompt-automation
+   ```
+4. Remove or edit that file to unregister or change the hotkey.
+
+After installation, press **Ctrl+Shift+J** to activate the launcher. If the hotkey fails, rerun the installer or consult your platform's hotkey settings.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -35,10 +35,13 @@ if (-not (Get-Command espanso -ErrorAction SilentlyContinue)) {
 }
 
 # Install AutoHotkey v2
-if (-not (Get-Command AutoHotkey -ErrorAction SilentlyContinue)) {
+$ahk = Get-Command AutoHotkey -ErrorAction SilentlyContinue
+if (-not $ahk) {
     Info "Installing AutoHotkey..."
     winget install -e --id AutoHotkey.AutoHotkey || Fail "Failed to install AutoHotkey"
+    $ahk = Get-Command AutoHotkey -ErrorAction SilentlyContinue
 }
+if (-not $ahk) { Fail "AutoHotkey not found in PATH after installation" }
 
 # Copy AHK script to Startup
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
@@ -47,7 +50,11 @@ $ahkSource = Resolve-Path $ahkSource
 $startup = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Startup\prompt-automation.ahk'
 try {
     Copy-Item -Path $ahkSource -Destination $startup -Force
-    Info "Registered prompt-automation hotkey script."
+    if (Test-Path $startup) {
+        Info "Registered prompt-automation hotkey script at $startup."
+    } else {
+        Fail "Failed to register AutoHotkey script"
+    }
 } catch {
     Write-Warning "Failed to register AutoHotkey script: $_"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,6 +61,21 @@ else
     info "espanso already installed"
 fi
 
+# Register global hotkey
+HOTKEY_SRC="$(cd "$(dirname "$0")/.." && pwd)/src/prompt_automation/hotkey"
+if [ "$PLATFORM" = "Linux" ] || [ "$PLATFORM" = "WSL2" ]; then
+    ESPANSO_MATCH_DIR="$HOME/.config/espanso/match"
+    mkdir -p "$ESPANSO_MATCH_DIR"
+    cp "$HOTKEY_SRC/linux.yaml" "$ESPANSO_MATCH_DIR/prompt-automation.yml"
+    info "Espanso hotkey added. Restarting espanso..."
+    espanso restart || true
+elif [ "$PLATFORM" = "macOS" ]; then
+    WORKFLOW_DIR="$HOME/Library/Application Scripts/prompt-automation"
+    mkdir -p "$WORKFLOW_DIR"
+    cp "$HOTKEY_SRC/macos.applescript" "$WORKFLOW_DIR/"
+    osascript -e 'tell application "System Events" to make login item at end with properties {path:"'$WORKFLOW_DIR'/macos.applescript", hidden:false}' || true
+fi
+
 # Install prompt-automation via pipx
 info "Installing prompt-automation..."
 pipx install --force prompt-automation || { err "Failed to install prompt-automation"; exit 1; }


### PR DESCRIPTION
## Summary
- document global hotkey setup for Windows/macOS/Linux
- link HOTKEYS.md in README
- copy hotkey files during install on Linux/macOS
- validate AutoHotkey install and startup registration on Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a675698c48328a31df66f3d451453