### PR TITLE
Enhance fallback handling and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Run the launcher and select **Option 99**. Provide style, ID, title, role, templ
 
 - **Behind a firewall?** Download the repo and run the installer scripts locally.
 - **Hotkey not working?** Re-run `prompt-automation` from the terminal to reset the hotkey integration.
+- **Need more help?** Run `prompt-automation --troubleshoot` and check `~/.prompt-automation/logs` for details.
 
 ## Uninstall
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,6 +4,12 @@ param()
 function Info($msg) { Write-Host $msg -ForegroundColor Green }
 function Fail($msg) { Write-Host $msg -ForegroundColor Red; exit 1 }
 
+$LogDir = Join-Path $env:USERPROFILE '.prompt-automation\logs'
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$LogFile = Join-Path $LogDir 'install.log'
+Start-Transcript -Path $LogFile -Append | Out-Null
+trap { Write-Warning "Error on line $($_.InvocationInfo.ScriptLineNumber). See $LogFile" }
+
 if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
     Fail "This installer must be run on Windows."
 }
@@ -64,3 +70,5 @@ Info "Installing prompt-automation via pipx..."
 pipx install --force prompt-automation || Fail "Failed to install prompt-automation"
 
 Info "Installation complete. You may need to log out and back in for hotkeys to activate."
+Stop-Transcript | Out-Null
+Info "Installation log saved to $LogFile"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+LOG_DIR="$HOME/.prompt-automation/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/install.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+trap 'err "Error on line $LINENO. See $LOG_FILE"' ERR
+
 info(){ echo -e "\033[1;32m$1\033[0m"; }
 err(){ echo -e "\033[1;31m$1\033[0m" >&2; }
 
@@ -81,3 +87,4 @@ info "Installing prompt-automation..."
 pipx install --force prompt-automation || { err "Failed to install prompt-automation"; exit 1; }
 
 info "Installation complete. You may need to restart your shell for PATH changes to take effect."
+info "Installation log saved to $LOG_FILE"

--- a/src/prompt_automation/__init__.py
+++ b/src/prompt_automation/__init__.py
@@ -7,4 +7,6 @@ __all__ = [
     "renderer",
     "paste",
     "logger",
+    "errorlog",
 ]
+

--- a/src/prompt_automation/cli.py
+++ b/src/prompt_automation/cli.py
@@ -1,6 +1,7 @@
 """Command line entrypoint with dependency checks."""
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import platform
@@ -87,7 +88,16 @@ def check_dependencies() -> bool:
     return True
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    """Program entry point."""
+    parser = argparse.ArgumentParser(prog="prompt-automation")
+    parser.add_argument("--troubleshoot", action="store_true", help="Show troubleshooting help")
+    args = parser.parse_args(argv)
+
+    if args.troubleshoot:
+        print("Troubleshooting tips:\n- Ensure dependencies are installed.\n- Logs stored at", LOG_DIR)
+        return
+
     _log.info("running on %s", platform.platform())
     if not check_dependencies():
         return
@@ -104,3 +114,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/src/prompt_automation/errorlog.py
+++ b/src/prompt_automation/errorlog.py
@@ -1,0 +1,18 @@
+import logging
+from pathlib import Path
+
+LOG_DIR = Path.home() / ".prompt-automation" / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "error.log"
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return logger writing to ``error.log``."""
+    logger = logging.getLogger(name)
+    if not any(isinstance(h, logging.FileHandler) and h.baseFilename == str(LOG_FILE) for h in logger.handlers):
+        handler = logging.FileHandler(LOG_FILE)
+        fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        handler.setFormatter(fmt)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/src/prompt_automation/paste.py
+++ b/src/prompt_automation/paste.py
@@ -1,24 +1,89 @@
-"""Clipboard helper using pyperclip and keyboard."""
+"""Clipboard helper using pyperclip with robust fallbacks."""
+from __future__ import annotations
+
 import platform
+import shutil
 import subprocess
+from typing import Any
 
 import pyperclip
+
+from .errorlog import get_logger
+
+
+_log = get_logger(__name__)
+
+
+def _is_wsl() -> bool:
+    rel = platform.uname().release.lower()
+    return "microsoft" in rel or "wsl" in rel
+
+
+def _copy_system(text: str, os_name: str) -> bool:
+    """Attempt system clipboard utilities."""
+    try:
+        if _is_wsl():
+            subprocess.run(["clip.exe"], input=text.encode(), check=True)
+            return True
+        if os_name == "Linux":
+            if shutil.which("xclip"):
+                subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode(), check=True)
+                return True
+            if shutil.which("wl-copy"):
+                subprocess.run(["wl-copy"], input=text.encode(), check=True)
+                return True
+        elif os_name == "Darwin":
+            subprocess.run(["pbcopy"], input=text.encode(), check=True)
+            return True
+        elif os_name == "Windows":
+            subprocess.run("clip", input=text.encode(), shell=True, check=True)
+            return True
+    except Exception as e:  # pragma: no cover - platform specific
+        _log.error("system copy failed: %s", e)
+    return False
 
 
 def paste_text(text: str) -> None:
     """Copy ``text`` to clipboard and simulate paste."""
-    pyperclip.copy(text)
     os_name = platform.system()
+    copied = False
+    try:
+        pyperclip.copy(text)
+        copied = True
+    except Exception as e:  # pragma: no cover - can't easily simulate
+        _log.error("pyperclip failed: %s", e)
+    if not copied:
+        _log.warning("pyperclip failed; attempting system clipboard")
+        copied = _copy_system(text, os_name)
+    if not copied:
+        print("[prompt-automation] Unable to copy text to clipboard. See error log.")
+        return
+
     try:
         if os_name == "Windows":
-            import keyboard
+            import keyboard  # type: ignore
+
             keyboard.send("ctrl+v")
         elif os_name == "Darwin":
             subprocess.run(
                 ["osascript", "-e", 'tell app "System Events" to keystroke "v" using command down'],
                 check=False,
             )
-        else:
+        elif os_name == "Linux" and shutil.which("xdotool"):
             subprocess.run(["xdotool", "key", "ctrl+v"], check=False)
-    except Exception:
-        pass
+        elif _is_wsl():
+            subprocess.run(
+                [
+                    "powershell.exe",
+                    "-Command",
+                    "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait('^v')",
+                ],
+                check=False,
+            )
+        else:
+            _log.warning("no method to send paste keystroke on %s", os_name)
+            print("[prompt-automation] Text copied. Paste manually (Ctrl+V).")
+    except Exception as e:  # pragma: no cover - platform specific
+        _log.error("sending paste key failed: %s", e)
+        print("[prompt-automation] Text copied. Paste manually (Ctrl+V). See error log.")
+

--- a/tests/test_troubleshoot.py
+++ b/tests/test_troubleshoot.py
@@ -1,0 +1,11 @@
+import sys
+
+sys.modules.setdefault("pyperclip", type("x", (), {"copy": lambda x: None}))
+from prompt_automation import cli
+
+
+def test_troubleshoot_flag(capsys):
+    cli.main(["--troubleshoot"])
+    out = capsys.readouterr().out
+    assert "Troubleshooting" in out
+


### PR DESCRIPTION
## Summary
- add global error logger and use it in clipboard and variable modules
- implement system clipboard fallbacks and WSL2 support
- extend CLI with `--troubleshoot` flag
- log installer output and save logs
- document new flag and log location
- add test for troubleshooting flag

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a703c9b94832883d02350c4c5cbc3