### PR TITLE
Improve documentation and add env var config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.2.1 - 2024-05-01
+- Documentation overhaul with install instructions, template management guide and advanced configuration.
+- `PROMPT_AUTOMATION_PROMPTS` and `PROMPT_AUTOMATION_DB` environment variables allow custom locations for templates and usage log.
+- Lint and test instructions added in CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thanks for wanting to contribute!
+
+## Running the Test Suite
+
+Install the test dependencies and run pytest from the project root:
+
+```bash
+pip install -e .[test]
+ruff check src tests
+pytest
+```
+
+Tests live under the `tests/` directory and cover basic functionality such as template loading and the CLI.
+
+## Linting and Build Steps
+
+We use [ruff](https://github.com/astral-sh/ruff) for linting. The command above will check the `src` and `tests` folders. The project is a standard Python package built with `setuptools`; nothing special is required when packaging beyond running the tests and linter.
+
+## Submitting Pull Requests
+
+1. Fork the repository and create a feature branch.
+2. Ensure `ruff check` and `pytest` succeed.
+3. Open a pull request describing the changes and reference any related issues.
+
+Happy hacking!

--- a/README.md
+++ b/README.md
@@ -1,71 +1,105 @@
 # prompt-automation
 
-**prompt-automation** is a keyboard-driven launcher for your favorite AI prompt templates.
+**prompt-automation** is a keyboard driven launcher for your favorite AI prompts. Press a hotkey, pick a template and the text is pasted wherever your cursor lives.
 
-## 1. Install prerequisites
+---
 
-### Windows 11
-1. Install [Git](https://git-scm.com/download/win).
-2. Open PowerShell as Administrator and run:
-   ```powershell
-   winget install -e --id Python.Python.3.11
-   winget install -e --id Microsoft.VisualStudioCode
-   winget install -e --id Git.Git
-   ```
+## Getting the Code
 
-### macOS 14
-1. Install [Homebrew](https://brew.sh) if missing.
-2. Run:
-   ```bash
-   brew install git python@3.11 --cask visual-studio-code
-   ```
-
-## 2. Clone this repository
+Clone the repository and change into the project directory:
 
 ```bash
 git clone https://github.com/<user>/prompt-automation.git
 cd prompt-automation
 ```
 
-## 3. Run the installer
+## OS Specific Installation
 
-### macOS/Linux
-```bash
-curl -sSL https://example.com/install.sh | bash
-```
-
-### Windows PowerShell
+### Windows 11
+Run the PowerShell installer:
 ```powershell
-iwr -useb https://example.com/install.ps1 | iex
+scripts\install.ps1
 ```
+The script installs Python, pipx, fzf, espanso and registers the **Ctrl+Shift+J** hotkey using AutoHotkey.
 
-After installation, restart your terminal or log out/in if prompted.
-Detailed hotkey setup instructions for each platform are available in
-[docs/HOTKEYS.md](docs/HOTKEYS.md).
-
-## 4. Try the hotkey
-
-Press **Ctrl+Shift+J** and a style picker will appear. Choose a template and the text is pasted automatically.
-
-```
-[Ctrl+Shift+J] -> [Style Picker] -> [Fill Placeholders] -> [Pasted Output]
-```
-
-## 5. Add a new prompt
-
-Run the launcher and select **Option 99**. Provide style, ID, title, role, template lines and placeholders when prompted. The new JSON template is saved under `prompts/styles/<Style>/` and is available immediately.
-
-## Troubleshooting
-
-- **Behind a firewall?** Download the repo and run the installer scripts locally.
-- **Hotkey not working?** Re-run `prompt-automation` from the terminal to reset the hotkey integration.
-- **Need more help?** Run `prompt-automation --troubleshoot` and check `~/.prompt-automation/logs` for details.
-
-## Uninstall
-
+### macOS 14
+Run the shell installer:
 ```bash
-pipx uninstall prompt-automation
-rm -rf ~/.prompt-automation
+bash scripts/install.sh
+```
+Homebrew is used to fetch dependencies. A small AppleScript registers the hotkey on login.
+
+### Linux
+Run the shell installer as above. It expects `apt` or `brew` and uses Espanso for the hotkey.
+
+### WSL2
+Run the Linux installer inside your distribution. Clipboard integration requires `clip.exe` in your Windows path.
+
+After installation restart your terminal session so `pipx` is on your `PATH`.
+
+## Launching and Hotkeys
+
+Press **Ctrl+Shift+J** to open the style picker. Hotkey troubleshooting and manual setup steps for each platform are documented in [docs/HOTKEYS.md](docs/HOTKEYS.md).
+
+## Using prompt-automation
+
+1. **Pick Style** – Choose a style category.
+2. **Pick Template** – Select the prompt template.
+3. **Fill Placeholders** – Enter any required values.
+4. **Paste** – The rendered text is copied to the clipboard and pasted for you.
+
+```
+[Hotkey] -> [Style] -> [Template] -> [Fill] -> [Paste]
+```
+
+Templates live under `prompts/styles/`. Selecting option `99` inside the style picker lets you create a new template interactively.
+
+## Managing Prompt Templates
+
+Template files are JSON documents stored in subfolders of `prompts/styles/`.
+Each file must contain:
+
+```json
+{
+  "id": 1,
+  "title": "My Template",
+  "style": "Utility",
+  "role": "assistant",
+  "template": ["Hello {{name}}"],
+  "placeholders": [{"name": "name", "label": "Name"}]
+}
+```
+
+The filename should start with a two digit ID: `01_my_template.json`.
+To edit an existing template simply modify the JSON file and rerun the launcher.
+
+## Usage Log
+
+Every time text is pasted an entry is recorded in `~/.prompt-automation/usage.db`.
+Delete this file to reset statistics.
+
+## Advanced Configuration
+
+Several environment variables allow custom paths:
+
+- `PROMPT_AUTOMATION_PROMPTS` – directory containing the `styles/` folders.
+- `PROMPT_AUTOMATION_DB` – path to the usage database.
+
+You can also modify the installed hotkey by editing the platform specific file in `src/prompt_automation/hotkey/` and rerunning the installer.
+
+## Directory Overview
+
+```
+project/
+├── docs/               # Additional documentation
+├── prompts/
+│   └── styles/         # Prompt JSON files
+├── scripts/            # Install helpers
+├── src/
+│   └── prompt_automation/
+│       ├── hotkey/     # Platform hotkey scripts
+│       └── ...         # Application modules
+└── tests/              # Test suite
 ```
 
 Enjoy!

--- a/src/prompt_automation/logger.py
+++ b/src/prompt_automation/logger.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime, timedelta
+import os
 from pathlib import Path
 from typing import Dict, Tuple
 
-DB_PATH = Path.home() / ".prompt-automation" / "usage.db"
+DEFAULT_DB_PATH = Path.home() / ".prompt-automation" / "usage.db"
+DB_PATH = Path(os.environ.get("PROMPT_AUTOMATION_DB", DEFAULT_DB_PATH))
 DB_PATH.parent.mkdir(exist_ok=True)
 
 

--- a/src/prompt_automation/menus.py
+++ b/src/prompt_automation/menus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -10,7 +11,8 @@ from . import logger
 from .renderer import fill_placeholders, load_template
 from .variables import get_variables
 
-PROMPTS_DIR = Path(__file__).resolve().parent.parent.parent / "prompts" / "styles"
+DEFAULT_PROMPTS_DIR = Path(__file__).resolve().parent.parent.parent / "prompts" / "styles"
+PROMPTS_DIR = Path(os.environ.get("PROMPT_AUTOMATION_PROMPTS", DEFAULT_PROMPTS_DIR))
 
 
 def _run_picker(items: List[str], title: str) -> Optional[str]:

--- a/src/prompt_automation/paste.py
+++ b/src/prompt_automation/paste.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import platform
 import shutil
 import subprocess
-from typing import Any
 
 import pyperclip
 

--- a/tests/test_troubleshoot.py
+++ b/tests/test_troubleshoot.py
@@ -1,7 +1,7 @@
 import sys
 
 sys.modules.setdefault("pyperclip", type("x", (), {"copy": lambda x: None}))
-from prompt_automation import cli
+from prompt_automation import cli  # noqa: E402
 
 
 def test_troubleshoot_flag(capsys):


### PR DESCRIPTION
## Summary
- add comprehensive README with installation and usage details
- document contributor steps in CONTRIBUTING.md
- start CHANGELOG and note env vars
- support `PROMPT_AUTOMATION_PROMPTS` and `PROMPT_AUTOMATION_DB`
- fix lint issues

## Testing
- `ruff check src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7276b1c88328ab6afc4e67c3e682