### PR TITLE
Fix install script syntax error

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -892,8 +892,7 @@ Debug "- AutoHotkey: $(if (Get-Command AutoHotkey -ErrorAction SilentlyContinue)
 Debug "- prompt-automation: $(if (Get-Command prompt-automation -ErrorAction SilentlyContinue) { 'Found' } else { 'Not found' })"
 
 Stop-Transcript | Out-Null
-Info "Installation log saved to $LogFile"{
-    Info "You can view the log for detailed information about the installation process."
-    Info "If you encounter any issues, please refer to the log for troubleshooting."
-    Info "Thank you for using prompt-automation!"
-}
+Info "Installation log saved to $LogFile"
+Info "You can view the log for detailed information about the installation process."
+Info "If you encounter any issues, please refer to the log for troubleshooting."
+Info "Thank you for using prompt-automation!"


### PR DESCRIPTION
## Summary
- fix closing braces in Windows install script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688bc55d1cd0832884f9619ca79032ca