### PR TITLE
Add PySimpleGUI GUI mode and update hotkeys

### DIFF
--- a/src/prompt_automation/gui.py
+++ b/src/prompt_automation/gui.py
@@ -1,0 +1,102 @@
+"""Simple GUI front-end for prompt selection and rendering."""
+from __future__ import annotations
+
+import sys
+from typing import Dict
+
+from . import logger, menus, paste
+
+
+def _build_placeholder_layout(sg, tmpl):
+    layout = []
+    for ph in tmpl.get("placeholders", []):
+        label = ph.get("label", ph["name"])
+        key = ph["name"]
+        if ph.get("options"):
+            layout.append([
+                sg.Text(label),
+                sg.Combo(ph["options"], key=key, size=(30, 1)),
+            ])
+        elif ph.get("multiline"):
+            layout.append([
+                sg.Text(label),
+                sg.Multiline(key=key, size=(30, 3)),
+            ])
+        else:
+            layout.append([sg.Text(label), sg.Input(key=key, size=(30, 1))])
+    return layout
+
+
+def run() -> None:
+    """Launch the GUI. Requires :mod:`PySimpleGUI`."""
+    try:
+        import PySimpleGUI as sg
+    except Exception as e:  # pragma: no cover - optional dependency
+        print("[prompt-automation] PySimpleGUI not available:", e, file=sys.stderr)
+        return
+
+    sg.theme("SystemDefault")
+    styles = menus.list_styles()
+    templates_cache: Dict[str, list[str]] = {}
+
+    layout = [
+        [sg.Text("Style"), sg.Input(key="-STYLE-FILTER-", enable_events=True)],
+        [
+            sg.Listbox(styles, size=(25, 10), key="-STYLE-", enable_events=True),
+            sg.Column(
+                [
+                    [sg.Text("Template"), sg.Input(key="-TEMPLATE-FILTER-", enable_events=True)],
+                    [sg.Listbox([], size=(30, 10), key="-TEMPLATE-", enable_events=True)],
+                ]
+            ),
+        ],
+        [sg.Column([], key="-PH-")],
+        [sg.Button("Render"), sg.Button("Paste"), sg.Button("Exit")],
+        [sg.Multiline(size=(80, 20), key="-OUTPUT-")],
+    ]
+
+    window = sg.Window("Prompt Automation", layout)
+    current_tmpl = None
+    while True:
+        event, values = window.read()
+        if event in (sg.WIN_CLOSED, "Exit"):
+            break
+        if event == "-STYLE-FILTER-":
+            query = values["-STYLE-FILTER-"].lower()
+            filtered = [s for s in styles if query in s.lower()]
+            window["-STYLE-"].update(filtered)
+        elif event == "-STYLE-":
+            sel = values["-STYLE-"]
+            if sel:
+                style = sel[0]
+                templates = [p.name for p in menus.list_prompts(style)]
+                templates_cache[style] = templates
+                window["-TEMPLATE-"].update(templates)
+                window["-TEMPLATE-FILTER-"].update("")
+        elif event == "-TEMPLATE-FILTER-":
+            sel = values["-STYLE-"]
+            if sel:
+                style = sel[0]
+                templates = templates_cache.get(style) or [p.name for p in menus.list_prompts(style)]
+                query = values["-TEMPLATE-FILTER-"].lower()
+                filtered = [t for t in templates if query in t.lower()]
+                window["-TEMPLATE-"].update(filtered)
+        elif event == "-TEMPLATE-":
+            style_sel = values["-STYLE-"]
+            tmpl_sel = values["-TEMPLATE-"]
+            if style_sel and tmpl_sel:
+                tmpl_path = menus.PROMPTS_DIR / style_sel[0] / tmpl_sel[0]
+                current_tmpl = menus.load_template(tmpl_path)
+                window["-PH-"].update(_build_placeholder_layout(sg, current_tmpl))
+        elif event == "Render" and current_tmpl:
+            ph_vals = {ph["name"]: values.get(ph["name"], "") for ph in current_tmpl.get("placeholders", [])}
+            text = menus.render_template(current_tmpl, ph_vals)
+            window["-OUTPUT-"].update(text)
+        elif event == "Paste" and current_tmpl:
+            ph_vals = {ph["name"]: values.get(ph["name"], "") for ph in current_tmpl.get("placeholders", [])}
+            text = menus.render_template(current_tmpl, ph_vals)
+            if text:
+                paste.paste_text(text)
+                logger.log_usage(current_tmpl, len(text))
+                window["-OUTPUT-"].update(text)
+    window.close()

--- a/src/prompt_automation/hotkey/linux.yaml
+++ b/src/prompt_automation/hotkey/linux.yaml
@@ -1,4 +1,4 @@
 matches:
   - trigger: "<ctrl>+<shift>+j"
-    run: "prompt-automation"
+    run: "prompt-automation --gui"
     propagate: false

--- a/src/prompt_automation/hotkey/macos.applescript
+++ b/src/prompt_automation/hotkey/macos.applescript
@@ -1,3 +1,3 @@
 on run
-    do shell script "prompt-automation &"
+    do shell script "prompt-automation --gui &"
 end run

--- a/src/prompt_automation/hotkey/windows.ahk
+++ b/src/prompt_automation/hotkey/windows.ahk
@@ -6,48 +6,9 @@
 #HotkeyInterval 99000000
 #KeyHistory 0
 
-; Ctrl+Shift+J to launch prompt-automation natively on Windows
+; Ctrl+Shift+J launches the prompt-automation GUI without opening a console
 ^+j::
 {
-    ; Show a tooltip to confirm hotkey is working
-    ToolTip, Launching prompt-automation...
-    SetTimer, RemoveToolTip, 1000
-    
-    ; Check if prompt-automation is already running to prevent multiple instances
-    Process, Exist, prompt-automation.exe
-    if (ErrorLevel > 0) {
-        ToolTip, prompt-automation is already running
-        SetTimer, RemoveToolTip, 2000
-        return
-    }
-    
-    ; Try Windows Terminal with PowerShell first (most reliable)
-    try {
-        Run, wt.exe powershell -NoExit -Command "if (Get-Command prompt-automation -ErrorAction SilentlyContinue) { prompt-automation } else { Write-Host 'ERROR: prompt-automation not found. Run scripts\install-prompt-automation.ps1 first.' -ForegroundColor Red; pause }", , UseErrorLevel
-        if (ErrorLevel = 0) {
-            return
-        }
-    }
-    
-    ; Fallback: Try Windows Terminal with Command Prompt
-    try {
-        Run, wt.exe cmd /k "prompt-automation || (echo ERROR: prompt-automation not found. Run scripts\install-prompt-automation.ps1 first. && pause)", , UseErrorLevel
-        if (ErrorLevel = 0) {
-            return
-        }
-    }
-    
-    ; Final fallback: Direct command prompt
-    try {
-        Run, cmd /k "prompt-automation || (echo ERROR: prompt-automation not found. Run scripts\install-prompt-automation.ps1 first. && pause)", , UseErrorLevel
-    } catch {
-        ToolTip, Failed to launch prompt-automation. Make sure it's installed with pipx.
-        SetTimer, RemoveToolTip, 5000
-    }
+    Run, prompt-automation.exe --gui,, Hide
     return
 }
-
-RemoveToolTip:
-    ToolTip
-    SetTimer, RemoveToolTip, Off
-return

--- a/src/prompt_automation/menus.py
+++ b/src/prompt_automation/menus.py
@@ -134,8 +134,14 @@ def pick_prompt(style: str) -> Optional[Dict[str, Any]]:
     return load_template(path)
 
 
-def render_template(tmpl: Dict[str, Any]) -> str:
-    vars = get_variables(tmpl.get("placeholders", []))
+def render_template(tmpl: Dict[str, Any], values: Dict[str, str] | None = None) -> str:
+    """Render ``tmpl`` using provided ``values`` for placeholders.
+
+    If ``values`` is ``None`` any missing variables will be collected via
+    :func:`variables.get_variables` which falls back to GUI/CLI prompts.
+    """
+
+    vars = get_variables(tmpl.get("placeholders", []), initial=values)
     return fill_placeholders(tmpl["template"], vars)
 
 


### PR DESCRIPTION
## Summary
- Add a PySimpleGUI-based `gui` module with searchable style/template lists and placeholder entry fields.
- Extend CLI with `--gui` flag and optional env var, skipping `fzf` when GUI is used.
- Allow `variables.get_variables` and `menus.render_template` to accept pre-filled values from the GUI.
- Update hotkey scripts to launch the GUI without a console window.

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_688deb996ae083289dbb0aca0b8f20bb