### PR TITLE
feat: add hotkey reassignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ __pycache__/
 *.pyd
 .pytest_cache/
 .coverage
+# Local config (logs, hotkey mappings)
 .prompt-automation/
 *.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Added interactive `--assign-hotkey` command with per-user hotkey mapping file
+
 ## 0.2.1 - 2025-08-01
 - Enhanced cross-platform compatibility for WSL2/Windows environments
 - Fixed Unicode character encoding issues in PowerShell scripts  

--- a/CODEBASE_REFERENCE.md
+++ b/CODEBASE_REFERENCE.md
@@ -19,6 +19,7 @@ This document provides a machine-readable and human-readable overview of the `pr
 │       ├── errorlog.py       # Shared logger that writes to ~/.prompt-automation/logs/error.log
 │       ├── gui.py            # Optional PySimpleGUI interface for choosing templates
 │       ├── hotkey/           # Platform-specific hotkey definitions
+│       ├── hotkeys.py        # Interactive hotkey assignment and system integration
 │       ├── logger.py         # Usage logging with SQLite rotation
 │       ├── menus.py          # Fzf-based style/template picker and template creation
 │       ├── paste.py          # Clipboard interaction and keystroke simulation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ After installation restart your terminal so `pipx` is on your `PATH`.
 
 ## Usage
 
-Press **Ctrl+Shift+J** to open the style picker. Select a style, choose a template and fill in any required values. The rendered text is copied to your clipboard and pasted automatically.
+Press **Ctrl+Shift+J** to launch the GUI style picker. Select a style, choose a template and fill in any required values. The rendered text is copied to your clipboard and pasted automatically.
+
+To change the global hotkey, run:
+
+```bash
+prompt-automation --assign-hotkey
+```
+and press the desired key combination.
 
 ```
 [Hotkey] -> [Style] -> [Template] -> [Fill] -> [Paste]

--- a/docs/HOTKEYS.md
+++ b/docs/HOTKEYS.md
@@ -1,7 +1,7 @@
 # Global Hotkey Setup
 
 This project provides platform-specific scripts for launching `prompt-automation` with a keyboard shortcut.
-The default key combination is **Ctrl+Shift+J**.
+The default key combination is **Ctrl+Shift+J**. Run `prompt-automation --assign-hotkey` to change it at any time.
 
 ## Windows
 1. Run `scripts/install.ps1` from PowerShell. The script installs dependencies, checks for AutoHotkey v2, and copies `windows.ahk` to your Startup folder.
@@ -9,7 +9,7 @@ The default key combination is **Ctrl+Shift+J**.
    ```powershell
    Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup" | Where-Object Name -eq 'prompt-automation.ahk'
    ```
-3. To unregister or change the hotkey, remove or edit `prompt-automation.ahk` from that folder and log out.
+3. To change the hotkey run `prompt-automation --assign-hotkey` or edit `prompt-automation.ahk` in that folder and log out.
 
 ## macOS
 1. Open `src/prompt_automation/hotkey/macos.applescript` with Automator and save it as an **Application**.
@@ -25,7 +25,7 @@ The default key combination is **Ctrl+Shift+J**.
 
 ## Linux / WSL2
 1. Ensure [Espanso](https://espanso.org) is installed.
-2. Copy `src/prompt_automation/hotkey/linux.yaml` to `$HOME/.config/espanso/match/prompt-automation.yml` and run `espanso restart`.
+2. Copy `src/prompt_automation/hotkey/linux.yaml` to `$HOME/.config/espanso/match/prompt-automation.yml` and run `espanso restart` (or use `prompt-automation --assign-hotkey`).
 3. If Espanso is unavailable, create `$HOME/.config/autostart/prompt-automation.desktop`:
    ```ini
    [Desktop Entry]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,6 +27,11 @@ trap { Write-Warning "Error on line $($_.InvocationInfo.ScriptLineNumber). See $
 
 Info "Starting prompt-automation installation..."
 
+# Record default hotkey mapping
+$cfgDir = Join-Path $env:USERPROFILE '.prompt-automation'
+New-Item -ItemType Directory -Force -Path $cfgDir | Out-Null
+@'{"hotkey": "ctrl+shift+j"}'@ | Set-Content (Join-Path $cfgDir 'hotkey.json')
+
 # Ensure we are running on Windows. If not, fall back to WSL-compatible installer
 if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
     Write-Warning 'Non-Windows environment detected. Running WSL-compatible installer if available.'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,6 +99,11 @@ elif [ "$PLATFORM" = "macOS" ]; then
     osascript -e 'tell application "System Events" to make login item at end with properties {path:"'$WORKFLOW_DIR'/macos.applescript", hidden:false}' || true
 fi
 
+# record default hotkey mapping
+HOTKEY_CFG_DIR="$HOME/.prompt-automation"
+mkdir -p "$HOTKEY_CFG_DIR"
+echo '{"hotkey": "ctrl+shift+j"}' > "$HOTKEY_CFG_DIR/hotkey.json"
+
 # Install prompt-automation via pipx
 info "Installing prompt-automation..."
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/prompt_automation/cli.py
+++ b/src/prompt_automation/cli.py
@@ -103,12 +103,23 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--list", action="store_true", help="List available prompt styles and templates")
     parser.add_argument("--reset-log", action="store_true", help="Clear usage log database")
     parser.add_argument("--gui", action="store_true", help="Launch GUI instead of terminal prompts")
+    parser.add_argument(
+        "--assign-hotkey",
+        action="store_true",
+        help="Interactively set or change the global GUI hotkey",
+    )
     args = parser.parse_args(argv)
 
     if args.prompt_dir:
         path = args.prompt_dir.expanduser().resolve()
         os.environ["PROMPT_AUTOMATION_PROMPTS"] = str(path)
         _log.info("using custom prompt directory %s", path)
+
+    if args.assign_hotkey:
+        from . import hotkeys
+
+        hotkeys.assign_hotkey()
+        return
 
     try:
         menus.ensure_unique_ids(menus.PROMPTS_DIR)

--- a/src/prompt_automation/hotkeys.py
+++ b/src/prompt_automation/hotkeys.py
@@ -1,0 +1,121 @@
+"""Utilities for assigning and updating global hotkeys."""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+
+CONFIG_DIR = Path.home() / ".prompt-automation"
+HOTKEY_FILE = CONFIG_DIR / "hotkey.json"
+
+
+def capture_hotkey() -> str:
+    """Capture a hotkey combination from the user.
+
+    Uses the ``keyboard`` package when available, otherwise falls back to a
+    simple text prompt. Returned hotkey strings use ``ctrl+shift+j`` style
+    notation.
+    """
+    try:  # pragma: no cover - optional dependency
+        import keyboard
+
+        print("Press desired hotkey combination...")
+        combo = keyboard.read_hotkey(suppress=False)
+        print(f"Captured hotkey: {combo}")
+        return combo
+    except Exception:  # pragma: no cover - fallback
+        return input("Enter hotkey (e.g. ctrl+shift+j): ").strip()
+
+
+def _to_espanso(hotkey: str) -> str:
+    parts = hotkey.lower().split("+")
+    mods, key = parts[:-1], parts[-1]
+    if mods:
+        return "+".join(f"<{m}>" for m in mods) + "+" + key
+    return key
+
+
+def _to_ahk(hotkey: str) -> str:
+    mapping = {"ctrl": "^", "shift": "+", "alt": "!", "win": "#", "cmd": "#"}
+    parts = hotkey.lower().split("+")
+    mods, key = parts[:-1], parts[-1]
+    return "".join(mapping.get(m, m) for m in mods) + key
+
+
+def save_mapping(hotkey: str) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    HOTKEY_FILE.write_text(json.dumps({"hotkey": hotkey}))
+
+
+def _update_linux(hotkey: str) -> None:
+    trigger = _to_espanso(hotkey)
+    match_dir = Path.home() / ".config" / "espanso" / "match"
+    match_dir.mkdir(parents=True, exist_ok=True)
+    yaml_path = match_dir / "prompt-automation.yml"
+    yaml_path.write_text(
+        f'matches:\n  - trigger: "{trigger}"\n    run: "prompt-automation --gui"\n    propagate: false\n'
+    )
+    try:  # pragma: no cover - external tool
+        subprocess.run(["espanso", "restart"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+
+def _update_windows(hotkey: str) -> None:
+    ahk_hotkey = _to_ahk(hotkey)
+    startup = (
+        Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+    )
+    startup.mkdir(parents=True, exist_ok=True)
+    script_path = startup / "prompt-automation.ahk"
+    content = (
+        "#NoEnv\n#SingleInstance Force\n#InstallKeybdHook\n#InstallMouseHook\n"
+        "#MaxHotkeysPerInterval 99000000\n#HotkeyInterval 99000000\n#KeyHistory 0\n\n"
+        f"; {hotkey} launches the prompt-automation GUI without opening a console\n"
+        f"{ahk_hotkey}::\n"
+        "{\n    Run, prompt-automation.exe --gui,, Hide\n    return\n}\n"
+    )
+    script_path.write_text(content)
+    try:  # pragma: no cover - external tool
+        subprocess.Popen(["AutoHotkey", str(script_path)])
+    except Exception:
+        pass
+
+
+def _update_macos(hotkey: str) -> None:  # pragma: no cover - macOS specific
+    script_dir = Path.home() / "Library" / "Application Scripts" / "prompt-automation"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script_path = script_dir / "macos.applescript"
+    script_path.write_text('on run\n    do shell script "prompt-automation --gui &"\nend run\n')
+    print(
+        "[prompt-automation] macOS hotkey updated. Assign the new hotkey via System Preferences > Keyboard > Shortcuts."
+    )
+
+
+def update_system_hotkey(hotkey: str) -> None:
+    system = platform.system()
+    if system == "Windows":
+        _update_windows(hotkey)
+    elif system == "Linux":
+        _update_linux(hotkey)
+    elif system == "Darwin":
+        _update_macos(hotkey)
+
+
+def assign_hotkey() -> None:
+    hotkey = capture_hotkey()
+    if not hotkey:
+        print("[prompt-automation] No hotkey provided")
+        return
+    save_mapping(hotkey)
+    update_system_hotkey(hotkey)
+    print(f"[prompt-automation] Hotkey set to {hotkey}")
+

--- a/tests/test_assign_hotkey.py
+++ b/tests/test_assign_hotkey.py
@@ -1,0 +1,15 @@
+import json
+import sys
+
+sys.modules.setdefault("pyperclip", type("x", (), {"copy": lambda *a: None}))
+from prompt_automation import cli, hotkeys
+
+
+def test_assign_hotkey_creates_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(hotkeys, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(hotkeys, "HOTKEY_FILE", tmp_path / "hotkey.json")
+    monkeypatch.setattr(hotkeys, "capture_hotkey", lambda: "ctrl+shift+k")
+    monkeypatch.setattr(hotkeys, "update_system_hotkey", lambda hotkey: None)
+    cli.main(["--assign-hotkey"])
+    data = json.loads((tmp_path / "hotkey.json").read_text())
+    assert data["hotkey"] == "ctrl+shift+k"


### PR DESCRIPTION
## Summary
- add `--assign-hotkey` option and hotkey management module
- record default hotkey mapping during install
- document and test hotkey reassignment

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892026e953c832891e3a013b0e16044