### PR TITLE
docs: streamline templates and GUI

### DIFF
--- a/CODEBASE_REFERENCE.md
+++ b/CODEBASE_REFERENCE.md
@@ -4,14 +4,13 @@ This document provides a machine-readable and human-readable overview of the `pr
 
 ## Project Summary
 
-`prompt-automation` is a cross-platform prompt launcher. A global hotkey triggers a style picker, renders a chosen template with user-provided values, copies the result to the clipboard and optionally pastes it into the active application.
+`prompt-automation` is a cross-platform prompt launcher. A global hotkey triggers a template picker, renders the selection with user-provided values, copies the result to the clipboard and optionally pastes it into the active application.
 
 ## Directory Structure
 
 ```
 .
 ├── docs/                     # Additional documentation such as hotkey setup
-├── prompts/                  # Prompt template JSON files grouped by style
 ├── scripts/                  # Installation and troubleshooting scripts (PowerShell/bash)
 ├── src/
 │   └── prompt_automation/
@@ -23,7 +22,7 @@ This document provides a machine-readable and human-readable overview of the `pr
 │       ├── logger.py         # Usage logging with SQLite rotation
 │       ├── menus.py          # Fzf-based style/template picker and template creation
 │       ├── paste.py          # Clipboard interaction and keystroke simulation
-│       ├── prompts/          # Packaged prompt templates
+│       ├── prompts/          # Packaged prompt templates (styles/basic/01_basic.json)
 │       ├── renderer.py       # Template loading, validation, and placeholder substitution
 │       ├── resources/        # Static assets like banner.txt
 │       ├── utils.py          # Safe subprocess execution helpers
@@ -61,7 +60,7 @@ This document provides a machine-readable and human-readable overview of the `pr
 
 ## Prompt Templates
 
-Prompt JSON files live under `prompts/styles/<Style>/`. Each template includes an integer `id`, a `title`, a `style`, a list of `template` lines, and optional `placeholders`. The application enforces unique IDs via `menus.ensure_unique_ids()`.
+Prompt JSON files live under `prompts/styles/<Style>/`. The repository bundles only `basic/01_basic.json` as a minimal example. Each template includes an integer `id`, a `title`, a `style`, a list of `template` lines, and optional `placeholders`. The application enforces unique IDs via `menus.ensure_unique_ids()`.
 
 ## Hotkey System Architecture
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,9 @@
 include README.md
 include LICENSE
-include pyproject.toml
-include README.md
-include LICENSE
 include CHANGELOG.md
 include CONTRIBUTING.md
 include pyproject.toml
 recursive-include src/prompt_automation *
-recursive-include prompts *
 global-exclude *.pyc
 global-exclude __pycache__
 recursive-include src/prompt_automation/resources *

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After installation restart your terminal so `pipx` is on your `PATH`.
 
 ## Usage
 
-Press **Ctrl+Shift+J** to launch the GUI style picker. Select a style, choose a template and fill in any required values. The rendered text is copied to your clipboard and pasted automatically.
+Press **Ctrl+Shift+J** to launch the GUI. Select the basic template and fill in any required values. The rendered text is copied to your clipboard and pasted automatically.
 
 The hotkey system automatically:
 - Tries to launch the GUI first
@@ -50,14 +50,15 @@ prompt-automation --update
 ```
 
 ```
-[Hotkey] -> [Style] -> [Template] -> [Fill] -> [Paste]
+[Hotkey] -> [Template] -> [Fill] -> [Paste]
 ```
 
-Templates live under `prompts/styles/`. Choosing option `99` in the style picker lets you create a new template interactively.
+Templates live under `prompts/styles/`. Only `basic/01_basic.json` is bundled for now, but you can add your own templates in the same directory structure.
 
 ## Managing Templates
 
 Template files are plain JSON documents in `prompts/styles/<Style>/`.
+This repository currently includes a single example: `basic/01_basic.json`.
 A minimal example:
 
 ```json
@@ -155,12 +156,11 @@ powershell.exe -Command "cd 'C:\\temp\\prompt-automation'; Copy-Item -Path '\\ws
 ```
 project/
 ├── docs/               # Additional documentation
-├── prompts/
-│   └── styles/         # Prompt JSON files
 ├── scripts/            # Install helpers
 ├── src/
 │   └── prompt_automation/
 │       ├── hotkey/     # Platform hotkey scripts
+│       ├── prompts/    # Contains styles/basic/01_basic.json
 │       └── ...         # Application modules
 ```
 


### PR DESCRIPTION
## Summary
- update docs for Tkinter-only GUI and single basic prompt template
- clean build manifest for minimal template packaging

## Testing
- `pip install pyperclip` *(fails: 403  Forbidden [IP: 172.30.1.67 8080])* 
- `PYTHONPATH=src python -m prompt_automation.cli --list` *(fails: ModuleNotFoundError: No module named 'pyperclip')*
- `bash scripts/install.sh` *(fails: repository 403 errors)*
- `pwsh -File scripts/install.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893442a5c0c83289dff91dc7c8b6177