### PR TITLE
feat: add review window and optional placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ After installation restart your terminal so `pipx` is on your `PATH`.
 
 ## Usage
 
-Press **Ctrl+Shift+J** to launch the GUI. Select the basic template and fill in any required values. The rendered text is copied to your clipboard but not pasted automatically.
+Press **Ctrl+Shift+J** to launch the GUI. Select the basic template and fill in
+any required values. After entering values an editable review window appears.
+Press **Ctrl+Enter** to finish (copies and closes) or **Ctrl+Shift+C** to copy
+without closing. To skip a placeholder leave it blank and submit with
+**Ctrl+Enter** – the entire line is removed from the final prompt. The rendered
+text is copied to your clipboard but not pasted automatically.
 
 The hotkey system automatically:
 - Tries to launch the GUI first
@@ -84,6 +89,10 @@ A minimal example:
   "placeholders": [{"name": "name", "label": "Name"}]
 }
 ```
+
+Global defaults for common placeholders live in `prompts/styles/globals.json`.
+Templates can omit these entries to use the defaults or override them by
+defining placeholders with the same names.
 
 ## Troubleshooting
 

--- a/src/prompt_automation/menus.py
+++ b/src/prompt_automation/menus.py
@@ -148,11 +148,18 @@ def render_template(tmpl: Dict[str, Any], values: Dict[str, Any] | None = None) 
     """Render ``tmpl`` using provided ``values`` for placeholders.
 
     If ``values`` is ``None`` any missing variables will be collected via
-    :func:`variables.get_variables` which falls back to GUI/CLI prompts.
+    :func:`variables.get_variables` which falls back to GUI/CLI prompts. When
+    ``values`` is supplied it is used as-is, allowing ``None`` entries to skip
+    placeholders.
     """
 
-    vars = get_variables(tmpl.get("placeholders", []), initial=values)
-    for ph in tmpl.get("placeholders", []):
+    placeholders = tmpl.get("placeholders", [])
+    if values is None:
+        vars = get_variables(placeholders)
+    else:
+        vars = dict(values)
+
+    for ph in placeholders:
         if ph.get("type") == "file":
             name = ph["name"]
             path = vars.get(name)
@@ -160,6 +167,7 @@ def render_template(tmpl: Dict[str, Any], values: Dict[str, Any] | None = None) 
                 vars[name] = read_file_safe(path)
             else:
                 vars[name] = ""
+
     return fill_placeholders(tmpl["template"], vars)
 
 


### PR DESCRIPTION
## Summary
- add editable review step after filling placeholders
- allow Ctrl+Enter to skip placeholder inputs and remove their lines
- document review window, skipping placeholders, and global defaults

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3fac5aa083289ac3be4cc98e8708