### PR TITLE
feat: add GUI skip reminder

### DIFF
--- a/src/prompt_automation/variables.py
+++ b/src/prompt_automation/variables.py
@@ -133,6 +133,19 @@ def _print_one_time_skip_reminder(data: dict, template_id: int, name: str) -> No
         template_id,
         _PERSIST_FILE,
     )
+    try:
+        import tkinter as tk  # type: ignore
+        from tkinter import messagebox
+
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showinfo(
+            "Reference file skipped",
+            f"Reference file ‘{name}’ skipped. You can reset this later.",
+        )
+        root.destroy()
+    except Exception:
+        print(f"Reference file ‘{name}’ skipped. You can reset this later.")
     _save_overrides(data)
 
 


### PR DESCRIPTION
## Summary
- show GUI or console message when a reference file is skipped
- reminder still printed only once per template/place-holder

## Testing
- `python -m py_compile src/prompt_automation/variables.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b39ec04808328b9038dfb1f30ffb4