### PR TITLE
feat: add reset reference files option

### DIFF
--- a/src/prompt_automation/gui.py
+++ b/src/prompt_automation/gui.py
@@ -13,6 +13,7 @@ from .variables import (
     _print_one_time_skip_reminder,
     _save_overrides,
     _set_template_entry,
+    reset_file_overrides,
 )
 
 
@@ -96,6 +97,32 @@ def select_template_gui():
     root.title("Select Template - Prompt Automation")
     root.geometry("600x400")
     root.resizable(False, False)
+
+    # menu for additional actions
+    menubar = tk.Menu(root)
+    root.config(menu=menubar)
+
+    def on_reset_refs():
+        if reset_file_overrides():
+            messagebox.showinfo(
+                "Reset reference files",
+                "Reference file prompts will reappear.",
+            )
+        else:
+            messagebox.showinfo(
+                "Reset reference files",
+                "No reference file overrides found.",
+            )
+
+    options_menu = tk.Menu(menubar, tearoff=0)
+    options_menu.add_command(
+        label="Reset reference files",
+        command=on_reset_refs,
+        accelerator="Ctrl+Shift+R",
+    )
+    menubar.add_cascade(label="Options", menu=options_menu)
+
+    root.bind("<Control-Shift-R>", lambda e: (on_reset_refs(), "break"))
     
     # Bring to foreground and focus
     root.lift()
@@ -262,6 +289,9 @@ def collect_file_variable_gui(template_id: int, placeholder: dict, globals_map: 
         p = Path(path_str).expanduser()
         if p.exists():
             return str(p)
+        # remove stale path so user is prompted again
+        overrides.get("templates", {}).get(str(template_id), {}).pop(name, None)
+        _save_overrides(overrides)
 
     root = tk.Tk()
     root.title(f"File: {label}")

--- a/src/prompt_automation/variables.py
+++ b/src/prompt_automation/variables.py
@@ -141,11 +141,13 @@ def _print_one_time_skip_reminder(data: dict, template_id: int, name: str) -> No
         root.withdraw()
         messagebox.showinfo(
             "Reference file skipped",
-            f"Reference file ‘{name}’ skipped. You can reset this later.",
+            f"Reference file ‘{name}’ skipped. Use 'Reset reference files' to re-enable prompts.",
         )
         root.destroy()
     except Exception:
-        print(f"Reference file ‘{name}’ skipped. You can reset this later.")
+        print(
+            f"Reference file ‘{name}’ skipped. Use 'Reset reference files' to re-enable prompts."
+        )
     _save_overrides(data)
 
 


### PR DESCRIPTION
## Summary
- add "Reset reference files" option to GUI with Ctrl+Shift+R shortcut
- remove stale file overrides and re-prompt when stored reference files vanish
- clarify skip reminder that reset option restores prompts

## Testing
- `python -m py_compile src/prompt_automation/gui.py src/prompt_automation/variables.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b3bb0ad9483289f67c3e6169e78b6