### PR TITLE
feat: append file placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
   - Better macOS AppleScript handling with background execution
   - Added `--update` command to refresh hotkey configuration and verify dependencies
   - Automatic hotkey script placement verification and error reporting
-  - Support for multiple installation methods (pip, pipx, executable, python -m)
+- Support for multiple installation methods (pip, pipx, executable, python -m)
 - Added interactive `--assign-hotkey` command with per-user hotkey mapping file
+- Added optional `append_file` placeholder to append rendered output to files
 
 ## 0.2.1 - 2025-08-01
 - Enhanced cross-platform compatibility for WSL2/Windows environments

--- a/README.md
+++ b/README.md
@@ -94,6 +94,31 @@ Global defaults for common placeholders live in `prompts/styles/globals.json`.
 Templates can omit these entries to use the defaults or override them by
 defining placeholders with the same names.
 
+### Appending output to a file
+
+File placeholders named `append_file` (or ending with `_append_file`) cause the
+final rendered text to be appended to the chosen path after you confirm the
+prompt with **Ctrl+Enter**. The text is written in UTF-8 with a trailing
+newline.
+
+Example template:
+
+```json
+{
+  "id": 45,
+  "title": "Append log entry",
+  "style": "Tool",
+  "template": ["{{entry}}"],
+  "placeholders": [
+    {"name": "entry", "label": "Log entry", "multiline": true},
+    {"name": "append_file", "label": "Log file", "type": "file"}
+  ]
+}
+```
+
+This will copy the prompt to your clipboard and also append it to the selected
+log file when confirmed.
+
 ## Troubleshooting
 
 - Run `prompt-automation --troubleshoot` to print log and database locations.

--- a/src/prompt_automation/prompts/styles/Tool/45_append-log-entry.json
+++ b/src/prompt_automation/prompts/styles/Tool/45_append-log-entry.json
@@ -1,0 +1,10 @@
+{
+  "id": 45,
+  "title": "Append log entry",
+  "style": "Tool",
+  "template": ["{{entry}}"],
+  "placeholders": [
+    {"name": "entry", "label": "Log entry", "multiline": true},
+    {"name": "append_file", "label": "Log file", "type": "file"}
+  ]
+}


### PR DESCRIPTION
## Summary
- allow `menus.render_template` to return variable map for file-aware workflows
- append rendered text to paths from `append_file` placeholders in CLI and GUI
- document and sample template demonstrating append-file support

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b405bb19c8328b357dcad9041f223