### PR TITLE
Centralize configuration paths and unify imports

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ global-exclude *.pyc
 global-exclude __pycache__
 recursive-include src/prompt_automation/resources *
 recursive-include src/prompt_automation/hotkey *
+include src/prompt_automation/config.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-prompt_automation = ["resources/*", "hotkey/*", "prompts/**/*"]
+prompt_automation = ["resources/*", "hotkey/*", "prompts/**/*", "config.py"]
 
 # Include prompts directory from root
 [tool.setuptools]

--- a/src/prompt_automation/config.py
+++ b/src/prompt_automation/config.py
@@ -1,0 +1,61 @@
+"""Central configuration paths for prompt-automation."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+# Environment variable names
+ENV_PROMPTS = "PROMPT_AUTOMATION_PROMPTS"
+ENV_DB = "PROMPT_AUTOMATION_DB"
+ENV_LOG_DIR = "PROMPT_AUTOMATION_LOG_DIR"
+ENV_HOME = "PROMPT_AUTOMATION_HOME"
+
+
+def _candidate_prompt_paths() -> List[Path]:
+    """Return potential locations for packaged or user prompts."""
+    return [
+        # Development structure (3 levels up from this file)
+        Path(__file__).resolve().parent.parent.parent / "prompts" / "styles",
+        # Packaged installation - data files location
+        Path(__file__).resolve().parent / "prompts" / "styles",
+        # Alternative package location (in site-packages)
+        Path(__file__).resolve().parent.parent / "prompts" / "styles",
+        # pipx virtual environment location
+        Path(__file__).resolve().parent.parent.parent / "Lib" / "prompts" / "styles",
+        # User locations
+        Path.home() / ".prompt-automation" / "prompts" / "styles",
+        Path.home() / ".local" / "share" / "prompt-automation" / "prompts" / "styles",
+        # System-wide locations
+        Path("/usr/local/share/prompt-automation/prompts/styles"),
+        Path("C:/ProgramData/prompt-automation/prompts/styles"),
+    ]
+
+
+PROMPTS_SEARCH_PATHS = _candidate_prompt_paths()
+
+
+def _find_prompts_dir() -> Path:
+    env_path = os.environ.get(ENV_PROMPTS)
+    if env_path:
+        env_prompts = Path(env_path).expanduser()
+        if env_prompts.exists():
+            return env_prompts
+    for location in PROMPTS_SEARCH_PATHS:
+        if location.exists() and location.is_dir():
+            return location
+    return PROMPTS_SEARCH_PATHS[0]
+
+
+PROMPTS_DIR = _find_prompts_dir()
+
+DEFAULT_HOME = Path.home() / ".prompt-automation"
+HOME_DIR = Path(os.environ.get(ENV_HOME, DEFAULT_HOME))
+HOME_DIR.mkdir(parents=True, exist_ok=True)
+
+LOG_DIR = Path(os.environ.get(ENV_LOG_DIR, HOME_DIR / "logs"))
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "error.log"
+
+DB_PATH = Path(os.environ.get(ENV_DB, HOME_DIR / "usage.db"))
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prompt_automation/errorlog.py
+++ b/src/prompt_automation/errorlog.py
@@ -1,9 +1,6 @@
 import logging
-from pathlib import Path
 
-LOG_DIR = Path.home() / ".prompt-automation" / "logs"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
-LOG_FILE = LOG_DIR / "error.log"
+from .config import LOG_DIR, LOG_FILE
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/src/prompt_automation/logger.py
+++ b/src/prompt_automation/logger.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timedelta
 import os
-from pathlib import Path
 from typing import Dict, Tuple
 
-_LOCK_FH = None
+from .config import DB_PATH
 
-DEFAULT_DB_PATH = Path.home() / ".prompt-automation" / "usage.db"
-DB_PATH = Path(os.environ.get("PROMPT_AUTOMATION_DB", DEFAULT_DB_PATH))
-DB_PATH.parent.mkdir(exist_ok=True)
+_LOCK_FH = None
 
 
 def _lock_db() -> None:

--- a/src/prompt_automation/menus.py
+++ b/src/prompt_automation/menus.py
@@ -3,57 +3,19 @@ from __future__ import annotations
 
 import json
 from .utils import safe_run
-import os
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from . import logger
-from .renderer import fill_placeholders, load_template, validate_template, read_file_safe
+from .config import PROMPTS_DIR, PROMPTS_SEARCH_PATHS
+from .renderer import (
+    fill_placeholders,
+    load_template,
+    validate_template,
+    read_file_safe,
+)
 from .variables import get_variables
-
-# Try to find prompts directory in multiple locations
-def _find_prompts_dir():
-    # Environment variable override
-    env_path = os.environ.get("PROMPT_AUTOMATION_PROMPTS")
-    if env_path:
-        env_prompts = Path(env_path)
-        if env_prompts.exists():
-            return env_prompts
-    
-    # List of potential locations in order of preference
-    locations = [
-        # Development structure (3 levels up from this file)
-        Path(__file__).resolve().parent.parent.parent / "prompts" / "styles",
-        
-        # Packaged installation - data files location
-        Path(__file__).resolve().parent / "prompts" / "styles",
-        
-        # Alternative package location (in site-packages)
-        Path(__file__).resolve().parent.parent / "prompts" / "styles",
-        
-        # pipx virtual environment location
-        Path(__file__).resolve().parent.parent.parent / "Lib" / "prompts" / "styles",
-        
-        # User's home directory
-        Path.home() / ".prompt-automation" / "prompts" / "styles",
-        Path.home() / ".local" / "share" / "prompt-automation" / "prompts" / "styles",
-        
-        # System-wide locations
-        Path("/usr/local/share/prompt-automation/prompts/styles"),
-        Path("C:/ProgramData/prompt-automation/prompts/styles"),  # Windows system-wide
-    ]
-    
-    # Try each location
-    for location in locations:
-        if location.exists() and location.is_dir():
-            return location
-    
-    # If none exist, return the development location as fallback
-    return locations[0]
-
-DEFAULT_PROMPTS_DIR = _find_prompts_dir()
-PROMPTS_DIR = Path(os.environ.get("PROMPT_AUTOMATION_PROMPTS", DEFAULT_PROMPTS_DIR))
 
 
 def _run_picker(items: List[str], title: str) -> Optional[str]:
@@ -89,12 +51,7 @@ def list_styles() -> List[str]:
         if not PROMPTS_DIR.exists():
             print(f"Warning: Prompts directory not found at {PROMPTS_DIR}")
             print("Available search locations were:")
-            for i, location in enumerate([
-                Path(__file__).resolve().parent.parent.parent / "prompts" / "styles",
-                Path(__file__).resolve().parent / "prompts" / "styles",
-                Path(__file__).resolve().parent.parent / "prompts" / "styles",
-                Path.home() / ".prompt-automation" / "prompts" / "styles",
-            ], 1):
+            for i, location in enumerate(PROMPTS_SEARCH_PATHS, 1):
                 exists = "✓" if location.exists() else "✗"
                 print(f"  {i}. {exists} {location}")
             return []

--- a/src/prompt_automation/variables.py
+++ b/src/prompt_automation/variables.py
@@ -10,37 +10,18 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import json
 
+from .config import HOME_DIR, PROMPTS_DIR
 from .errorlog import get_logger
 
 
 _log = get_logger(__name__)
 
 # Persistence for file placeholders & skip flags
-_PERSIST_DIR = Path.home() / ".prompt-automation"
+_PERSIST_DIR = HOME_DIR
 _PERSIST_FILE = _PERSIST_DIR / "placeholder-overrides.json"
 
 # Settings file (lives alongside templates so it can be edited via GUI / under VCS if desired)
-def _locate_prompts_root() -> Path:
-    """Best-effort discovery of the prompts/styles directory.
-
-    We intentionally avoid importing ``menus`` here to prevent circular imports.
-    Order of resolution:
-      1. PROMPT_AUTOMATION_PROMPTS env var
-      2. Package relative path (installed)
-      3. Development relative path
-    """
-    env = os.environ.get("PROMPT_AUTOMATION_PROMPTS")
-    if env:
-        p = Path(env).expanduser()
-        if p.exists():
-            return p
-    pkg_local = Path(__file__).resolve().parent / "prompts" / "styles"
-    if pkg_local.exists():
-        return pkg_local
-    dev_local = Path(__file__).resolve().parent.parent.parent / "prompts" / "styles"
-    return dev_local
-
-_SETTINGS_DIR = _locate_prompts_root() / "Settings"
+_SETTINGS_DIR = PROMPTS_DIR / "Settings"
 _SETTINGS_FILE = _SETTINGS_DIR / "settings.json"
 
 def _load_settings_payload() -> Dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import prompt_automation.config as config
+
+
+def _reload(monkeypatch):
+    return importlib.reload(config)
+
+
+def test_prompts_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv(config.ENV_PROMPTS, str(tmp_path))
+    mod = _reload(monkeypatch)
+    assert mod.PROMPTS_DIR == tmp_path
+
+
+def test_prompts_default_location(monkeypatch, tmp_path):
+    monkeypatch.delenv(config.ENV_PROMPTS, raising=False)
+    default = tmp_path / ".prompt-automation" / "prompts" / "styles"
+    default.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    mod = _reload(monkeypatch)
+    mod.PROMPTS_SEARCH_PATHS = [default]
+    assert mod._find_prompts_dir() == default
+
+
+def test_env_overrides_db_and_log(monkeypatch, tmp_path):
+    db = tmp_path / "usage.db"
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv(config.ENV_DB, str(db))
+    monkeypatch.setenv(config.ENV_LOG_DIR, str(log_dir))
+    mod = _reload(monkeypatch)
+    assert mod.DB_PATH == db
+    assert mod.LOG_DIR == log_dir
+
+
+def test_default_db_and_log(monkeypatch, tmp_path):
+    for env in (config.ENV_DB, config.ENV_LOG_DIR, config.ENV_HOME):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    mod = _reload(monkeypatch)
+    assert mod.DB_PATH == tmp_path / ".prompt-automation" / "usage.db"
+    assert mod.LOG_DIR == tmp_path / ".prompt-automation" / "logs"
+


### PR DESCRIPTION
## Summary
- add `Config` constants in new `config.py` for prompts, logs, DB and env vars
- refactor menus, variables, logger and errorlog to use centralized paths
- include config in package data and provide tests for environment overrides and defaults

## Testing
- `python -m py_compile src/prompt_automation/config.py src/prompt_automation/menus.py src/prompt_automation/variables.py src/prompt_automation/logger.py src/prompt_automation/errorlog.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6526865483289257f7fa52bada3b