### PR TITLE
Remove invoke build helper and document python -m build

### DIFF
--- a/CODEBASE_REFERENCE.md
+++ b/CODEBASE_REFERENCE.md
@@ -35,14 +35,13 @@ This document provides a machine-readable and human-readable overview of the `pr
 │       ├── resources/        # Static assets like banner.txt
 │       ├── utils.py          # Safe subprocess execution helpers
 │       └── variables.py      # Collect values for placeholders via GUI/editor/CLI; manages per-template file path/skip overrides
-├── tasks.py                  # Invoke tasks for building distributions
 └── ...                       # Root configuration files (pyproject.toml, README.md, etc.)
 ```
 
 ## Component Interaction
 
 1. **Entry Points**
-   - `cli.main()` runs when the command-line tool is invoked. It performs dependency checks and launches either the terminal picker or the GUI.
+   - `cli.main()` runs when the command-line tool starts. It performs dependency checks and launches either the terminal picker or the GUI.
    - `gui.gui.run()` provides a graphical front-end when `--gui` is supplied.
 2. **Hotkey System**
    - `hotkeys.assign_hotkey()` captures user input and configures platform-specific global hotkeys
@@ -64,7 +63,7 @@ This document provides a machine-readable and human-readable overview of the `pr
 ## Scripts and Utilities
 
  - `install/install.sh`, `install/install.ps1`, and related scripts automate installation on Linux/macOS/Windows.
- - `tasks.py` defines an Invoke task for building distributable packages (`invoke build`).
+ - Build distributions with `python -m build`.
 
 ## Prompt Templates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ pip install -e .
 ## Submitting Pull Requests
 
 1. Fork the repository and create a feature branch.
-2. Run `invoke build` to ensure the package builds.
+2. Run `python -m build` to ensure the package builds.
 3. Open a pull request describing the changes and reference any related issues.
 
 Happy hacking!

--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ After tagging/publishing push:
 git push && git push --tags
 ```
 
+### Manual Build
+
+To build the package without the release script, run:
+
+```bash
+python -m build
+```
+
 ### Continuous Auto-Release (GitHub Actions)
 
 An automated workflow (`.github/workflows/auto-release.yml`) bumps the patch version and publishes to PyPI on every push to `main` (excluding pure docs / workflow changes). To request a larger bump include a marker in any recent commit message:

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,0 @@
-from invoke import task
-
-
-@task
-def build(c):
-    c.run("python -m build")


### PR DESCRIPTION
## Summary
- remove unused `tasks.py` Invoke helper
- document `python -m build` usage in CONTRIBUTING and developer docs
- add manual build instructions to README

## Testing
- `pytest`
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f178abc8328be147421d22c5697