### PR TITLE
Refactor prompt templates to standardized structure

### DIFF
--- a/src/prompt_automation/prompts/styles/Code/01_track-bug.json
+++ b/src/prompt_automation/prompts/styles/Code/01_track-bug.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Track Bug.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 1,
   "title": "Track Bug",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/track-bug.json",
+    "path": "Code/01_track-bug.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/09_llm-coding-reminders.json
+++ b/src/prompt_automation/prompts/styles/Code/09_llm-coding-reminders.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Llm Coding Reminders.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 9,
   "title": "Llm Coding Reminders",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/llm-coding-reminders.json",
+    "path": "Code/09_llm-coding-reminders.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/10_agentic-workflow-orchestration.json
+++ b/src/prompt_automation/prompts/styles/Code/10_agentic-workflow-orchestration.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Agentic Workflow Orchestration.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 10,
   "title": "Agentic Workflow Orchestration",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/agentic-workflow-orchestration.json",
+    "path": "Code/10_agentic-workflow-orchestration.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/11_start-dev-project-two-parter.json
+++ b/src/prompt_automation/prompts/styles/Code/11_start-dev-project-two-parter.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Start Dev Project Two Parter.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 11,
   "title": "Start Dev Project Two Parter",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/start-dev-project-two-parter.json",
+    "path": "Code/11_start-dev-project-two-parter.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/13_add-feature.json
+++ b/src/prompt_automation/prompts/styles/Code/13_add-feature.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Add Feature.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 13,
   "title": "Add Feature",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/add-feature.json",
+    "path": "Code/13_add-feature.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/14_write-tests.json
+++ b/src/prompt_automation/prompts/styles/Code/14_write-tests.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Write Tests.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 14,
   "title": "Write Tests",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/write-tests.json",
+    "path": "Code/14_write-tests.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/15_read-code-analysis.json
+++ b/src/prompt_automation/prompts/styles/Code/15_read-code-analysis.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Read Code Analysis.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 15,
   "title": "Read Code Analysis",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/read-code-analysis.json",
+    "path": "Code/15_read-code-analysis.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/20_security-pentesting-unbiased.json
+++ b/src/prompt_automation/prompts/styles/Code/20_security-pentesting-unbiased.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Security Pentesting Unbiased.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 20,
   "title": "Security Pentesting Unbiased",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/security-pentesting-unbiased.json",
+    "path": "Code/20_security-pentesting-unbiased.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/Code-Cleanup/18_cleanup-efficiency.json
+++ b/src/prompt_automation/prompts/styles/Code/Code-Cleanup/18_cleanup-efficiency.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Cleanup Efficiency.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 18,
   "title": "Cleanup Efficiency",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/Code-Cleanup/cleanup-efficiency.json",
+    "path": "Code/Code-Cleanup/18_cleanup-efficiency.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/Code-Cleanup/19_cleanup-maintainability.json
+++ b/src/prompt_automation/prompts/styles/Code/Code-Cleanup/19_cleanup-maintainability.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Cleanup Maintainability.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 19,
   "title": "Cleanup Maintainability",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/Code-Cleanup/cleanup-maintainability.json",
+    "path": "Code/Code-Cleanup/19_cleanup-maintainability.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Code/Troubleshoot/16_this-will-be-the-title-of-the-prompt.json
+++ b/src/prompt_automation/prompts/styles/Code/Troubleshoot/16_this-will-be-the-title-of-the-prompt.json
@@ -1,9 +1,32 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for This will be the title of the prompt.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 16,
   "title": "This will be the title of the prompt",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    }
+  ],
   "template": [
     "Is this in the final window or the beginning window?",
     "{{objective}}",
@@ -15,45 +38,8 @@
     "{{instructions}}",
     ""
   ],
-  "placeholders": [
-    {
-      "name": "reference_file",
-      "label": "Select a Reference File",
-      "type": "file",
-      "required": false,
-      "default": "",
-      "description": "Select once; path stored per template. Will re-prompt if missing."
-    },
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": false,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": false,
-      "default": "Objective - test to see if it automatically fills in if I just 'enter'"
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no",
-    "reference_file_default": ""
-  },
   "metadata": {
-    "path": "Code/Troubleshoot/troubleshoot-reminders.json",
+    "path": "Code/Troubleshoot/16_this-will-be-the-title-of-the-prompt.json",
     "tags": [],
     "version": 2,
     "render": "text",

--- a/src/prompt_automation/prompts/styles/Code/Troubleshoot/17_troubleshoot-specific-tool.json
+++ b/src/prompt_automation/prompts/styles/Code/Troubleshoot/17_troubleshoot-specific-tool.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Troubleshoot Specific Tool.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 17,
   "title": "Troubleshoot Specific Tool",
   "style": "Code",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Code/Troubleshoot/troubleshoot-specific-tool.json",
+    "path": "Code/Troubleshoot/17_troubleshoot-specific-tool.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/21_quick-verify.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/21_quick-verify.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Quick Verify.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 21,
   "title": "Quick Verify",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/quick-verify.json",
+    "path": "Decision-Making/21_quick-verify.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/22_bias-reminders-and-questions.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/22_bias-reminders-and-questions.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Bias Reminders And Questions.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 22,
   "title": "Bias Reminders And Questions",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/bias-reminders-and-questions.json",
+    "path": "Decision-Making/22_bias-reminders-and-questions.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/General-Frameworks/23_steelman-opposite.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/General-Frameworks/23_steelman-opposite.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Steelman Opposite.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 23,
   "title": "Steelman Opposite",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/General-Frameworks/steelman-opposite.json",
+    "path": "Decision-Making/General-Frameworks/23_steelman-opposite.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/General-Frameworks/24_decision-framework-from-book.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/General-Frameworks/24_decision-framework-from-book.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Decision Framework From Book.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 24,
   "title": "Decision Framework From Book",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/General-Frameworks/decision-framework-from-book.json",
+    "path": "Decision-Making/General-Frameworks/24_decision-framework-from-book.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/PAIN/25_pain-quick-command.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/PAIN/25_pain-quick-command.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Pain Quick Command.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 25,
   "title": "Pain Quick Command",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/PAIN/pain-quick-command.json",
+    "path": "Decision-Making/PAIN/25_pain-quick-command.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Decision-Making/PAIN/26_speak-or-not-filters.json
+++ b/src/prompt_automation/prompts/styles/Decision-Making/PAIN/26_speak-or-not-filters.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Speak Or Not Filters.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 26,
   "title": "Speak Or Not Filters",
   "style": "Decision-Making",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Decision-Making/PAIN/speak-or-not-filters.json",
+    "path": "Decision-Making/PAIN/26_speak-or-not-filters.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/27_one-shot.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/27_one-shot.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for One Shot.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 27,
   "title": "One Shot",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/one-shot.json",
+    "path": "LLM-Techniques/27_one-shot.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/28_few-shot.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/28_few-shot.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Few Shot.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 28,
   "title": "Few Shot",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/few-shot.json",
+    "path": "LLM-Techniques/28_few-shot.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/29_meta-prompt.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/29_meta-prompt.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Meta Prompt.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 29,
   "title": "Meta Prompt",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/meta-prompt.json",
+    "path": "LLM-Techniques/29_meta-prompt.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/30_context-refresh.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/30_context-refresh.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Context Refresh.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 30,
   "title": "Context Refresh",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/context-refresh.json",
+    "path": "LLM-Techniques/30_context-refresh.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/31_crit.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/31_crit.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Crit.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 31,
   "title": "Crit",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/crit.json",
+    "path": "LLM-Techniques/31_crit.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/32_agentic-workflow-starred.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/32_agentic-workflow-starred.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Agentic Workflow Starred.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 32,
   "title": "Agentic Workflow Starred",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Advanced-Workflows/agentic-workflow-starred.json",
+    "path": "LLM-Techniques/Advanced-Workflows/32_agentic-workflow-starred.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/33_rag.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/33_rag.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Rag.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 33,
   "title": "Rag",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Advanced-Workflows/rag.json",
+    "path": "LLM-Techniques/Advanced-Workflows/33_rag.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/34_tree-of-thoughts-decision-tree.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/34_tree-of-thoughts-decision-tree.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Tree Of Thoughts Decision Tree.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 34,
   "title": "Tree Of Thoughts Decision Tree",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Advanced-Workflows/tree-of-thoughts-decision-tree.json",
+    "path": "LLM-Techniques/Advanced-Workflows/34_tree-of-thoughts-decision-tree.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/35_chain-of-thought.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Advanced-Workflows/35_chain-of-thought.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Chain Of Thought.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 35,
   "title": "Chain Of Thought",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Advanced-Workflows/chain-of-thought.json",
+    "path": "LLM-Techniques/Advanced-Workflows/35_chain-of-thought.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/36_graph-and-mindmap.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/36_graph-and-mindmap.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Graph And Mindmap.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 36,
   "title": "Graph And Mindmap",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Follow-Up/graph-and-mindmap.json",
+    "path": "LLM-Techniques/Follow-Up/36_graph-and-mindmap.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/37_make-prompt-from-good-outcome.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/37_make-prompt-from-good-outcome.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Make Prompt From Good Outcome.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 37,
   "title": "Make Prompt From Good Outcome",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Follow-Up/make-prompt-from-good-outcome.json",
+    "path": "LLM-Techniques/Follow-Up/37_make-prompt-from-good-outcome.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/38_troubleshoot-improve-prompt.json
+++ b/src/prompt_automation/prompts/styles/LLM-Techniques/Follow-Up/38_troubleshoot-improve-prompt.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Troubleshoot Improve Prompt.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 38,
   "title": "Troubleshoot Improve Prompt",
   "style": "LLM-Techniques",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "LLM-Techniques/Follow-Up/troubleshoot-improve-prompt.json",
+    "path": "LLM-Techniques/Follow-Up/38_troubleshoot-improve-prompt.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Plans/05_comprehensive-plan.json
+++ b/src/prompt_automation/prompts/styles/Plans/05_comprehensive-plan.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Comprehensive Plan.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 5,
   "title": "Comprehensive Plan",
   "style": "Plans",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Plans/comprehensive-plan.json",
+    "path": "Plans/05_comprehensive-plan.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Plans/06_break-plan-by-context-length.json
+++ b/src/prompt_automation/prompts/styles/Plans/06_break-plan-by-context-length.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Break Plan By Context Length.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 6,
   "title": "Break Plan By Context Length",
   "style": "Plans",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Plans/break-plan-by-context-length.json",
+    "path": "Plans/06_break-plan-by-context-length.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Plans/07_improve-ambiguous-plan.json
+++ b/src/prompt_automation/prompts/styles/Plans/07_improve-ambiguous-plan.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Improve Ambiguous Plan.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 7,
   "title": "Improve Ambiguous Plan",
   "style": "Plans",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Plans/improve-ambiguous-plan.json",
+    "path": "Plans/07_improve-ambiguous-plan.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Plans/08_project-worthiness-and-integration.json
+++ b/src/prompt_automation/prompts/styles/Plans/08_project-worthiness-and-integration.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Project Worthiness And Integration.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 8,
   "title": "Project Worthiness And Integration",
   "style": "Plans",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Plans/project-worthiness-and-integration.json",
+    "path": "Plans/08_project-worthiness-and-integration.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Summaries/40_summarize-text-article.json
+++ b/src/prompt_automation/prompts/styles/Summaries/40_summarize-text-article.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Summarize Text Article.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 40,
   "title": "Summarize Text Article",
   "style": "Summaries",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Summaries/summarize-text-article.json",
+    "path": "Summaries/40_summarize-text-article.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Summaries/41_summarize-book.json
+++ b/src/prompt_automation/prompts/styles/Summaries/41_summarize-book.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Summarize Book.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 41,
   "title": "Summarize Book",
   "style": "Summaries",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Summaries/summarize-book.json",
+    "path": "Summaries/41_summarize-book.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/Summaries/42_summarize-podcast-video.json
+++ b/src/prompt_automation/prompts/styles/Summaries/42_summarize-podcast-video.json
@@ -1,9 +1,62 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Summarize Podcast Video.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 42,
   "title": "Summarize Podcast Video",
   "style": "Summaries",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "follow_ups",
+      "label": "Follow Ups",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    }
+  ],
   "template": [
     "## Objective",
     "{{objective}}",
@@ -29,102 +82,8 @@
     "## Follow-ups",
     "{{follow_ups}}"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "label": "Role",
-      "multiline": false,
-      "required": true,
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "label": "Objective",
-      "multiline": false,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "label": "Context",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "label": "Instructions",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "label": "Inputs",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "label": "Constraints",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "label": "Output Format",
-      "multiline": true,
-      "required": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "label": "Quality Checks",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "label": "Follow-ups",
-      "multiline": true,
-      "required": false,
-      "default": ""
-    },
-    {
-      "name": "importance",
-      "label": "Importance (Hallucination Guard Level)",
-      "multiline": false,
-      "required": false,
-      "default": "normal",
-      "description": "How important is correctness? Suggested: low | normal | high | critical."
-    },
-    {
-      "name": "think_deeply",
-      "label": "Think Deeply (Use Sparingly)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. Reminder: you only have so many deep-think invocations."
-    },
-    {
-      "name": "two_parter",
-      "label": "Two-Parter Flow (Paste + Follow Up)",
-      "multiline": false,
-      "required": false,
-      "default": "no",
-      "description": "yes | no. If yes, expect a second pass after initial paste."
-    }
-  ],
-  "global_placeholders": {
-    "importance": "normal",
-    "think_deeply": "no",
-    "two_parter": "no"
-  },
   "metadata": {
-    "path": "Summaries/summarize-podcast-video.json",
+    "path": "Summaries/42_summarize-podcast-video.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/tests/subfolder_tests/44_test1.json
+++ b/src/prompt_automation/prompts/styles/tests/subfolder_tests/44_test1.json
@@ -1,9 +1,74 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for test1.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 44,
   "title": "test1",
   "style": "tests",
-  "role": "{{role}}",
+  "placeholders": [
+    {
+      "name": "company_name",
+      "label": "Company Name",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "hallucinate",
+      "label": "Hallucinate",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "instructions",
+      "label": "Instructions",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "output_format",
+      "label": "Output Format",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "quality_checks",
+      "label": "Quality Checks",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "role",
+      "label": "Role",
+      "multiline": false,
+      "default": ""
+    }
+  ],
   "template": [
     "{{role}}",
     "",
@@ -33,60 +98,8 @@
     "{{company_name}}",
     "// this is a comment (No explicit think_deeply or reminders tokens; they will append automatically.)"
   ],
-  "placeholders": [
-    {
-      "name": "role",
-      "default": "assistant"
-    },
-    {
-      "name": "objective",
-      "multiline": false,
-      "default": ""
-    },
-    {
-      "name": "context",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "instructions",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "inputs",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "constraints",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "output_format",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "quality_checks",
-      "multiline": true,
-      "default": ""
-    },
-    {
-      "name": "follow_ups",
-      "multiline": true,
-      "default": " this is a comment // (hallucinate & reminders removed so they come only from globals)"
-    }
-  ],
-  "global_placeholders": {
-    "hallucinate": "normal",
-    "think_deeply": "no",
-    "reminders": "- Item 1\n- Item 2",
-    "company_name": " this is a comment // (hallucinate & reminders removed so they come only from globals)"
-  },
   "metadata": {
-    "path": "tests/test1.json",
+    "path": "tests/subfolder_tests/44_test1.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/tests/subfolder_tests/91_comprehensive-code-review.json
+++ b/src/prompt_automation/prompts/styles/tests/subfolder_tests/91_comprehensive-code-review.json
@@ -1,47 +1,72 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Comprehensive Code Review.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 91,
   "title": "Comprehensive Code Review",
   "style": "Code",
-  "role": "{{role}}",
   "placeholders": [
     {
-      "name": "role",
-      "default": "assistant"
+      "name": "company_name",
+      "label": "Company Name",
+      "multiline": false,
+      "default": ""
     },
     {
-      "name": "objective",
-      "default": "Review the given code for correctness, efficiency, and style."
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
     },
     {
       "name": "context",
+      "label": "Context",
+      "multiline": true,
+      "default": ""
+    },
+    {
+      "name": "hallucinate",
+      "label": "Hallucinate",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "inputs",
+      "label": "Inputs",
       "multiline": true,
       "default": ""
     },
     {
       "name": "instructions",
-      "multiline": true,
-      "default": "Provide constructive feedback and suggest improvements."
-    },
-    {
-      "name": "inputs",
+      "label": "Instructions",
       "multiline": true,
       "default": ""
     },
     {
-      "name": "constraints",
-      "multiline": true,
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
       "default": ""
     },
     {
       "name": "output_format",
+      "label": "Output Format",
       "multiline": true,
-      "default": "Summary of issues found with suggestions for improvements."
+      "default": ""
     },
     {
       "name": "quality_checks",
+      "label": "Quality Checks",
       "multiline": true,
-      "default": "No critical bugs; follows coding standards; efficient algorithms."
+      "default": ""
+    },
+    {
+      "name": "role",
+      "label": "Role",
+      "multiline": false,
+      "default": ""
     }
   ],
   "template": [
@@ -72,11 +97,8 @@
     "",
     "{{company_name}}"
   ],
-  "global_placeholders": {
-    "hallucinate": "normal"
-  },
   "metadata": {
-    "path": "Code/91_code_review.json",
+    "path": "tests/subfolder_tests/91_comprehensive-code-review.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/tests/subfolder_tests/92_decision-making-analysis.json
+++ b/src/prompt_automation/prompts/styles/tests/subfolder_tests/92_decision-making-analysis.json
@@ -1,52 +1,78 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Decision-Making Analysis.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 92,
   "title": "Decision-Making Analysis",
   "style": "Decision-Making",
-  "role": "{{role}}",
   "placeholders": [
     {
-      "name": "role",
-      "default": "assistant"
+      "name": "company_name",
+      "label": "Company Name",
+      "multiline": false,
+      "default": ""
     },
     {
-      "name": "objective",
-      "default": "Evaluate options and recommend the best choice based on criteria."
-    },
-    {
-      "name": "context",
+      "name": "constraints",
+      "label": "Constraints",
       "multiline": true,
       "default": ""
     },
     {
-      "name": "options",
-      "type": "list",
+      "name": "context",
+      "label": "Context",
+      "multiline": true,
       "default": ""
     },
     {
       "name": "criteria",
-      "type": "list",
+      "label": "Criteria",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "hallucinate",
+      "label": "Hallucinate",
+      "multiline": false,
       "default": ""
     },
     {
       "name": "instructions",
-      "multiline": true,
-      "default": "Analyze each option against each criterion, weigh pros and cons, and provide a recommendation."
-    },
-    {
-      "name": "constraints",
+      "label": "Instructions",
       "multiline": true,
       "default": ""
     },
     {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "options",
+      "label": "Options",
+      "multiline": false,
+      "default": ""
+    },
+    {
       "name": "output_format",
+      "label": "Output Format",
       "multiline": true,
-      "default": "A table comparing options versus criteria, followed by a recommendation paragraph."
+      "default": ""
     },
     {
       "name": "quality_checks",
+      "label": "Quality Checks",
       "multiline": true,
-      "default": "Clearly justify recommendation; consider all options; align with objectives."
+      "default": ""
+    },
+    {
+      "name": "role",
+      "label": "Role",
+      "multiline": false,
+      "default": ""
     }
   ],
   "template": [
@@ -80,11 +106,8 @@
     "",
     "{{company_name}}"
   ],
-  "global_placeholders": {
-    "hallucinate": "normal"
-  },
   "metadata": {
-    "path": "Decision-Making/92_decision_analysis.json",
+    "path": "tests/subfolder_tests/92_decision-making-analysis.json",
     "tags": [],
     "version": 1,
     "render": "markdown",

--- a/src/prompt_automation/prompts/styles/tests/subfolder_tests/93_prompt-troubleshooting.json
+++ b/src/prompt_automation/prompts/styles/tests/subfolder_tests/93_prompt-troubleshooting.json
@@ -1,47 +1,72 @@
 {
   "schema": 1,
+  "_comment": [
+    "Template for Prompt Troubleshooting.",
+    "Auto-refactored for standard placeholder structure."
+  ],
   "id": 93,
   "title": "Prompt Troubleshooting",
   "style": "Troubleshooting",
-  "role": "{{role}}",
   "placeholders": [
     {
-      "name": "role",
-      "default": "assistant"
+      "name": "company_name",
+      "label": "Company Name",
+      "multiline": false,
+      "default": ""
     },
     {
-      "name": "objective",
-      "default": "Diagnose and resolve issues with a prompt that is producing unsatisfactory results."
+      "name": "constraints",
+      "label": "Constraints",
+      "multiline": true,
+      "default": ""
     },
     {
       "name": "context",
+      "label": "Context",
       "multiline": true,
       "default": ""
     },
     {
       "name": "errors",
-      "multiline": true,
+      "label": "Errors",
+      "multiline": false,
+      "default": ""
+    },
+    {
+      "name": "hallucinate",
+      "label": "Hallucinate",
+      "multiline": false,
       "default": ""
     },
     {
       "name": "instructions",
-      "multiline": true,
-      "default": "Identify the root causes of the issues, suggest modifications to the prompt structure or content, and propose remedies."
-    },
-    {
-      "name": "constraints",
+      "label": "Instructions",
       "multiline": true,
       "default": ""
     },
     {
+      "name": "objective",
+      "label": "Objective",
+      "multiline": false,
+      "default": ""
+    },
+    {
       "name": "output_format",
+      "label": "Output Format",
       "multiline": true,
-      "default": "A step-by-step analysis of the issue followed by recommended changes."
+      "default": ""
     },
     {
       "name": "quality_checks",
+      "label": "Quality Checks",
       "multiline": true,
-      "default": "Proposed fixes address the root causes; no introduction of hallucinations; maintain clarity and relevance."
+      "default": ""
+    },
+    {
+      "name": "role",
+      "label": "Role",
+      "multiline": false,
+      "default": ""
     }
   ],
   "template": [
@@ -72,11 +97,8 @@
     "",
     "{{company_name}}"
   ],
-  "global_placeholders": {
-    "hallucinate": "normal"
-  },
   "metadata": {
-    "path": "Troubleshooting/93_troubleshooting_prompt.json",
+    "path": "tests/subfolder_tests/93_prompt-troubleshooting.json",
     "tags": [],
     "version": 1,
     "render": "markdown",


### PR DESCRIPTION
## Summary
- standardize prompt template JSON files and add explanatory `_comment` sections
- normalize placeholder fields and update metadata paths for all styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1964a9988328a881260462ad27ee