### PR TITLE
Add baseline render snapshot tests

### DIFF
--- a/tests/test_legacy_module_imports.py
+++ b/tests/test_legacy_module_imports.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+
+def test_legacy_gui_modules_import_no_side_effect():
+    import tkinter
+    assert tkinter._default_root is None
+
+    # Legacy module paths should remain importable without creating a root window
+    from prompt_automation.gui import single_window, new_template_wizard
+    from prompt_automation.gui.collector import prompts
+    from prompt_automation.gui.selector import view
+
+    assert single_window is not None
+    assert prompts is not None
+    assert view is not None
+    assert new_template_wizard is not None
+    assert tkinter._default_root is None

--- a/tests/test_render_golden.py
+++ b/tests/test_render_golden.py
@@ -1,0 +1,82 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import prompt_automation.menus as menus
+import prompt_automation.variables as vars_mod
+
+
+def test_render_pipeline_golden(tmp_path, monkeypatch):
+    """Full render snapshot covering defaults, reminders, multi-file placeholders,
+    list formatting, phrase removal and trimming."""
+    # Set up globals with reminders and think_deeply auto append
+    gdata = {
+        'global_placeholders': {
+            'think_deeply': 'THINK',
+            'reminders': ['Remember A', 'Remember B'],
+        }
+    }
+    (tmp_path / 'globals.json').write_text(json.dumps(gdata))
+
+    # Route prompts dir to temp and change cwd so relative file paths resolve
+    monkeypatch.setattr(menus, 'PROMPTS_DIR', tmp_path)
+    monkeypatch.setattr(vars_mod, 'PROMPTS_DIR', tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # File placeholders
+    (tmp_path / 'ref.txt').write_text('REF CONTENT')
+    (tmp_path / 'sec.txt').write_text('SEC CONTENT')
+
+    tmpl = {
+        'id': 1,
+        'title': 'Golden',
+        'style': 'Unit',
+        'template': [
+            'Hello {{name}}',
+            '',
+            'Tasks:',
+            '{{tasks}}',
+            '',
+            'Optional: {{optional_line}}',
+            'Reference file path: {{reference_file_path}}',
+            'Reference file content: {{reference_file}}',
+            'Secondary path: {{secondary_file_path}}',
+            'Secondary content: {{secondary_file}}',
+        ],
+        'placeholders': [
+            {'name': 'name', 'default': 'World'},
+            {'name': 'tasks', 'format': 'checklist'},
+            {'name': 'reference_file', 'type': 'file'},
+            {'name': 'secondary_file', 'type': 'file'},
+            {'name': 'optional_line', 'remove_if_empty': 'Optional:'},
+        ],
+        'global_placeholders': {},
+    }
+
+    rendered = menus.render_template(
+        tmpl,
+        values={
+            'tasks': ['task one', 'task two'],
+            'reference_file': 'ref.txt',
+            'secondary_file': 'sec.txt',
+            'optional_line': '',
+        },
+    )
+
+    expected = (
+        'Hello World\n\n'
+        'Tasks:\n'
+        '- [ ] task one\n'
+        '- [ ] task two\n\n'
+        'Reference file path: ref.txt\n'
+        'Reference file content: REF CONTENT\n'
+        'Secondary path: sec.txt\n'
+        'Secondary content: SEC CONTENT\n\n'
+        'Reminders:\n'
+        '> - Remember A\n'
+        '> - Remember B\n\n'
+        'THINK'
+    )
+    assert rendered == expected


### PR DESCRIPTION
## Summary
- add full render pipeline golden test covering defaults, reminders, multi-file placeholders, formatting, phrase removal, and trimming
- add regression test ensuring legacy GUI modules remain importable without side effects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c41734608328ae883882321a90d8