### PR TITLE
feat: centralize GUI constants and add template types

### DIFF
--- a/src/prompt_automation/__init__.py
+++ b/src/prompt_automation/__init__.py
@@ -1,5 +1,7 @@
 """prompt-automation package."""
 
+from .types import Template, Placeholder
+
 __all__ = [
     "cli",
     "menus",
@@ -8,5 +10,7 @@ __all__ = [
     "paste",
     "logger",
     "errorlog",
+    "Template",
+    "Placeholder",
 ]
 

--- a/src/prompt_automation/gui/__init__.py
+++ b/src/prompt_automation/gui/__init__.py
@@ -13,5 +13,6 @@ from __future__ import annotations
 
 from .controller import PromptGUI  # noqa: F401
 from .gui import run  # re-export wrapper function
+from . import constants
 
-__all__ = ["PromptGUI", "run"]
+__all__ = ["PromptGUI", "run", "constants"]

--- a/src/prompt_automation/gui/collector/components/orchestrator.py
+++ b/src/prompt_automation/gui/collector/components/orchestrator.py
@@ -10,6 +10,7 @@ from .formatting import (
     truncate_default_hint,
 )
 from ....renderer import read_file_safe
+from ...constants import INSTR_ACCEPT_RESET_REFRESH_CANCEL
 from ..persistence import (
     CANCELLED,
     CURRENT_DEFAULTS,
@@ -77,7 +78,7 @@ def collect_file_variable_gui(template_id: int, placeholder: dict, globals_map: 
 
         top = tk.Frame(viewer, padx=14, pady=8)
         top.pack(fill="x")
-        instr = tk.Label(top, text="Ctrl+Enter = Continue   |   Ctrl+R = Reset   |   Ctrl+U = Refresh   |   Esc = Cancel", fg="#444")
+        instr = tk.Label(top, text=INSTR_ACCEPT_RESET_REFRESH_CANCEL, fg="#444")
         instr.pack(side="left")
 
         text_frame = tk.Frame(viewer)
@@ -180,7 +181,7 @@ def collect_reference_file_variable_gui(template_id: int, placeholder: dict):
 
         top = tk.Frame(viewer, padx=14, pady=8)
         top.pack(fill="x")
-        instr = tk.Label(top, text="Ctrl+Enter = Continue   |   Ctrl+R = Reset   |   Ctrl+U = Refresh   |   Esc = Cancel", fg="#444")
+        instr = tk.Label(top, text=INSTR_ACCEPT_RESET_REFRESH_CANCEL, fg="#444")
         instr.pack(side="left")
 
         text_frame = tk.Frame(viewer)
@@ -291,7 +292,7 @@ def collect_global_reference_file_gui(placeholder: dict):
         viewer.lift(); viewer.focus_force(); viewer.attributes("-topmost", True); viewer.after(100, lambda: viewer.attributes("-topmost", False))
         action = {"value": "cancel"}
         top = tk.Frame(viewer, padx=14, pady=8); top.pack(fill="x")
-        instr = tk.Label(top, text="Ctrl+Enter = Continue   |   Ctrl+R = Reset   |   Ctrl+U = Refresh   |   Esc = Cancel", fg="#444")
+        instr = tk.Label(top, text=INSTR_ACCEPT_RESET_REFRESH_CANCEL, fg="#444")
         instr.pack(side="left")
         # Text area
         text_frame = tk.Frame(viewer); text_frame.pack(fill="both", expand=True)

--- a/src/prompt_automation/gui/constants.py
+++ b/src/prompt_automation/gui/constants.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+# Shared GUI instruction strings and hotkey labels.
+INSTR_ACCEPT_RESET_REFRESH_CANCEL = (
+    "Ctrl+Enter = Continue   |   Ctrl+R = Reset   |   Ctrl+U = Refresh   |   Esc = Cancel"
+)
+INSTR_FINISH_COPY_CLOSE = (
+    "Ctrl+Enter = Finish (copies & closes), Ctrl+Shift+C = Copy without closing, Esc = Cancel"
+)
+INSTR_FINISH_COPY_AGAIN = (
+    "Ctrl+Enter = Finish (copies & closes), Ctrl+Shift+C = Copy again, Esc = Cancel"
+)
+INFO_CLOSE_SAVE = "Ctrl+Enter/Esc = Close & Save"
+
+__all__ = [
+    "INSTR_ACCEPT_RESET_REFRESH_CANCEL",
+    "INSTR_FINISH_COPY_CLOSE",
+    "INSTR_FINISH_COPY_AGAIN",
+    "INFO_CLOSE_SAVE",
+]

--- a/src/prompt_automation/gui/options_menu.py
+++ b/src/prompt_automation/gui/options_menu.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict
 
 from ..errorlog import get_logger
+from .constants import INFO_CLOSE_SAVE
 
 _log = get_logger(__name__)
 
@@ -180,7 +181,7 @@ def configure_options_menu(
             raw_mode = {'value': False}
             toggle_btn = tk.Button(top, text='Raw', width=5); toggle_btn.pack(side='left', padx=(6,0))
             copy_btn = tk.Button(top, text='Copy', width=6); copy_btn.pack(side='left', padx=(6,0))
-            info = tk.Label(top, text='Ctrl+Enter/Esc = Close & Save', fg='#555'); info.pack(side='left', padx=(12,0))
+            info = tk.Label(top, text=INFO_CLOSE_SAVE, fg='#555'); info.pack(side='left', padx=(12,0))
             frame = tk.Frame(win); frame.pack(fill='both', expand=True)
             txt = tk.Text(frame, wrap='word'); vs = tk.Scrollbar(frame, orient='vertical', command=txt.yview)
             txt.configure(yscrollcommand=vs.set); txt.pack(side='left', fill='both', expand=True); vs.pack(side='right', fill='y')

--- a/src/prompt_automation/gui/review_window.py
+++ b/src/prompt_automation/gui/review_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from ..menus import render_template
 from .. import paste
+from .constants import INSTR_FINISH_COPY_CLOSE, INSTR_FINISH_COPY_AGAIN
 
 
 def review_output_gui(template, variables):
@@ -41,7 +42,7 @@ def review_output_gui(template, variables):
     instructions_var = tk.StringVar()
     instructions_var.set(
         "Edit the prompt below (this text is fully editable & will be copied). "
-        "Ctrl+Enter = Finish (copies & closes), Ctrl+Shift+C = Copy without closing, Esc = Cancel"
+        + INSTR_FINISH_COPY_CLOSE
     )
     instructions = tk.Label(
         main_frame,
@@ -83,8 +84,7 @@ def review_output_gui(template, variables):
             paste.copy_to_clipboard(text)
             status_var.set("Copied to clipboard ✔")
             instructions_var.set(
-                "Copied. You can keep editing. Ctrl+Enter = Finish (copies & closes), "
-                "Ctrl+Shift+C = Copy again, Esc = Cancel"
+                "Copied. You can keep editing. " + INSTR_FINISH_COPY_AGAIN
             )
             # Clear status after a delay
             root.after(4000, lambda: status_var.set(""))

--- a/src/prompt_automation/menus/__init__.py
+++ b/src/prompt_automation/menus/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from ..config import PROMPTS_DIR, PROMPTS_SEARCH_PATHS
 from ..renderer import (
@@ -13,6 +13,9 @@ from ..renderer import (
     read_file_safe,
     is_shareable,
 )
+
+if TYPE_CHECKING:
+    from ..types import Template
 from ..variables import (
     get_variables,
     ensure_template_global_snapshot,
@@ -43,7 +46,7 @@ from .render_pipeline import (
 # --- Rendering -------------------------------------------------------------
 
 def render_template(
-    tmpl: Dict[str, Any],
+    tmpl: "Template",
     values: Dict[str, Any] | None = None,
     *,
     return_vars: bool = False,

--- a/src/prompt_automation/menus/creation.py
+++ b/src/prompt_automation/menus/creation.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import json
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
 
 from ..config import PROMPTS_DIR
 from ..renderer import validate_template
+
+if TYPE_CHECKING:
+    from ..types import Template, Placeholder
 
 # NOTE: Slug logic removed. Filenames are now stable once created. We keep a
 # tiny helper for backwards compatibility if any external code imported it.
@@ -32,7 +35,7 @@ def _check_unique_id(pid: int, exclude: Path | None = None) -> None:
             continue
 
 
-def save_template(data: Dict[str, Any], orig_path: Path | None = None) -> Path:
+def save_template(data: "Template", orig_path: Path | None = None) -> Path:
     """Persist ``data`` without automatic renaming based on title.
 
     Rules now:
@@ -89,7 +92,7 @@ def ensure_unique_ids(base: Path = PROMPTS_DIR) -> None:
     free integer greater than the current max.
     """
     paths = sorted(base.rglob("*.json"))
-    templates: List[tuple[Path, Dict[str, Any]]] = []
+    templates: List[tuple[Path, "Template"]] = []
     problems: List[str] = []
     used: set[int] = set()
 
@@ -155,12 +158,12 @@ def create_new_template() -> None:
         if line == ".":
             break
         body.append(line)
-    placeholders: List[Dict[str, Any]] = []
+    placeholders: List["Placeholder"] = []
     print("Placeholder names comma separated (empty to finish):")
     names = input()
     for name in [n.strip() for n in names.split(",") if n.strip()]:
         placeholders.append({"name": name})
-    data = {
+    data: "Template" = {
         "id": int(pid),
         "title": title,
         "style": style,

--- a/src/prompt_automation/renderer.py
+++ b/src/prompt_automation/renderer.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence, Union, Any
+from typing import Dict, Iterable, List, Sequence, Union, Any, TYPE_CHECKING
 
 from .errorlog import get_logger
+
+if TYPE_CHECKING:
+    from .types import Template
 
 _log = get_logger(__name__)
 
@@ -102,7 +105,7 @@ def _coerce_bool(val: Any) -> bool | None:
     return None
 
 
-def inject_share_flag(data: Dict[str, Any], path: Path) -> None:
+def inject_share_flag(data: "Template", path: Path) -> None:
     """Ensure ``metadata.share_this_file_openly`` exists & normalized.
 
     Behaviour:
@@ -133,7 +136,7 @@ def inject_share_flag(data: Dict[str, Any], path: Path) -> None:
         meta_obj["share_this_file_openly"] = coerced
 
 
-def is_shareable(template: Dict[str, Any], path: Path) -> bool:
+def is_shareable(template: "Template", path: Path) -> bool:
     """Return True if template should be considered share/export eligible.
 
     Precedence order:
@@ -155,7 +158,7 @@ def is_shareable(template: Dict[str, Any], path: Path) -> bool:
         return True
 
 
-def load_template(path: Path) -> Dict:
+def load_template(path: Path) -> "Template":
     """Load JSON template file, injecting share flag defaults."""
     path = path.expanduser().resolve()
     if not path.is_file():

--- a/src/prompt_automation/types.py
+++ b/src/prompt_automation/types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict, List, Dict, Any
+
+
+class Placeholder(TypedDict, total=False):
+    """Placeholder entry in a template."""
+
+    name: str
+    label: NotRequired[str]
+    default: NotRequired[str]
+    multiline: NotRequired[bool]
+    format: NotRequired[str]
+
+
+class Template(TypedDict, total=False):
+    """Prompt template structure."""
+
+    id: int
+    title: str
+    style: str
+    template: List[str]
+    placeholders: List[Placeholder]
+    role: NotRequired[str]
+    schema: NotRequired[int]
+    metadata: NotRequired[Dict[str, Any]]
+
+
+__all__ = ["Template", "Placeholder"]


### PR DESCRIPTION
## Summary
- centralize repeated GUI instruction strings
- define Template and Placeholder TypedDicts and wire into menus and renderer
- expose constants and types via package `__all__`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd403edc8328bfdcfa03102a4d5d