### PR TITLE
feat: add multi-select merging service

### DIFF
--- a/src/prompt_automation/gui/selector/view/orchestrator.py
+++ b/src/prompt_automation/gui/selector/view/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from ....services.multi_select import merge_templates
 from .preview import open_preview
 from .overrides import manage_overrides
 from .exclusions import edit_exclusions
@@ -37,13 +38,7 @@ class SelectorView:
 
     def finish_multi(self) -> Optional[dict]:
         """Combine selected templates into a synthetic multi template."""
-        if not self.multi_selected:
-            return None
-        combined = {
-            'title': f"Multi ({len(self.multi_selected)})",
-            'style': 'multi',
-            'template': sum((t.get('template', []) for t in self.multi_selected), []),
-        }
+        combined = merge_templates(self.multi_selected)
         self.multi_selected = []
         return combined
 

--- a/src/prompt_automation/services/multi_select.py
+++ b/src/prompt_automation/services/multi_select.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Utilities for combining multiple templates into a single synthetic one.
+
+This service exposes helpers used by GUI and CLI components to merge several
+prompt templates into a synthetic template whose body is simply the
+concatenation of the individual templates' lines.  It also supports loading
+templates by file path or shortcut key before merging.  Duplicate templates are
+ignored while preserving the order of first occurrence.
+"""
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from ..renderer import load_template
+from .template_search import resolve_shortcut
+
+
+def merge_templates(templates: Iterable[dict]) -> Optional[dict]:
+    """Return a synthetic template combining ``templates``.
+
+    Parameters
+    ----------
+    templates:
+        Iterable of template dictionaries.  Templates that appear multiple
+        times are only included once, keeping the first occurrence order.
+
+    Returns
+    -------
+    dict | None
+        Synthetic template dictionary with concatenated ``template`` lines, or
+        ``None`` if no templates were provided.
+    """
+    unique: List[dict] = []
+    seen_ids = set()
+    for tmpl in templates:
+        try:
+            tid = tmpl.get("id")
+        except AttributeError:
+            tid = id(tmpl)
+        if tid is None:
+            tid = id(tmpl)
+        if tid in seen_ids:
+            continue
+        seen_ids.add(tid)
+        unique.append(tmpl)
+    if not unique:
+        return None
+    combined_lines: List[str] = []
+    for tmpl in unique:
+        combined_lines.extend(tmpl.get("template", []))
+    return {
+        "id": -1,
+        "title": f"Multi ({len(unique)})",
+        "style": "multi",
+        "template": combined_lines,
+    }
+
+
+def merge_paths(paths: Iterable[str | Path]) -> Optional[dict]:
+    """Load templates from ``paths`` and merge them."""
+    loaded: List[dict] = []
+    seen: set[str] = set()
+    for p in paths:
+        path = Path(p)
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            loaded.append(load_template(path))
+        except Exception:
+            continue
+    return merge_templates(loaded)
+
+
+def merge_shortcuts(keys: Iterable[str]) -> Optional[dict]:
+    """Resolve shortcut ``keys`` and merge resulting templates."""
+    loaded: List[dict] = []
+    seen: set[int] = set()
+    for key in keys:
+        tmpl = resolve_shortcut(str(key))
+        if not tmpl:
+            continue
+        tid = tmpl.get("id", id(tmpl))
+        if tid in seen:
+            continue
+        seen.add(tid)
+        loaded.append(tmpl)
+    return merge_templates(loaded)
+
+
+__all__ = ["merge_templates", "merge_paths", "merge_shortcuts"]

--- a/tests/services/test_multi_select.py
+++ b/tests/services/test_multi_select.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+import prompt_automation.services.multi_select as ms
+import prompt_automation.services.template_search as ts
+from prompt_automation.shortcuts import save_shortcuts
+
+
+def _make_template(base: Path, rel: str, lines: list[str]) -> Path:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": sum(rel.encode()),
+        "title": rel,
+        "style": "Test",
+        "template": lines,
+        "placeholders": [],
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _setup_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(ts, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr("prompt_automation.config.PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr("prompt_automation.shortcuts.PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(
+        "prompt_automation.shortcuts.SETTINGS_DIR", tmp_path / "Settings"
+    )
+    monkeypatch.setattr(
+        "prompt_automation.shortcuts.SHORTCUT_FILE",
+        tmp_path / "Settings/template-shortcuts.json",
+    )
+    # ensure multi_select uses patched resolver
+    monkeypatch.setattr(ms, "resolve_shortcut", ts.resolve_shortcut)
+
+
+def test_merge_paths_order_and_dedup(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    t1 = _make_template(tmp_path, "a.json", ["A"])
+    t2 = _make_template(tmp_path, "b.json", ["B", "C"])
+    merged = ms.merge_paths([t1, t2])
+    assert merged["template"] == ["A", "B", "C"]
+    # duplicate paths ignored and order preserved
+    merged_dup = ms.merge_paths([t2, t1, t2])
+    assert merged_dup["template"] == ["B", "C", "A"]
+
+
+def test_merge_templates_duplicates():
+    t1 = {"id": 1, "template": ["X"]}
+    t2 = {"id": 2, "template": ["Y"]}
+    merged = ms.merge_templates([t1, t1, t2])
+    assert merged["template"] == ["X", "Y"]
+    assert merged["title"] == "Multi (2)"
+    assert merged["style"] == "multi"
+    assert merged["id"] == -1
+
+
+def test_merge_shortcut_keys(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    t1 = _make_template(tmp_path, "alpha.json", ["Alpha"])
+    t2 = _make_template(tmp_path, "beta.json", ["Beta"])
+    save_shortcuts({
+        "1": str(t1.relative_to(tmp_path)),
+        "2": str(t2.relative_to(tmp_path)),
+    })
+    merged = ms.merge_shortcuts(["1", "2", "1"])
+    assert merged["template"] == ["Alpha", "Beta"]


### PR DESCRIPTION
## Summary
- add `services.multi_select` for combining templates by path, shortcut, or loaded dicts
- cover merging order, deduplication, and shortcut lookup with new tests
- delegate GUI selector multi-finish logic to multi-select service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60d3e9dbc8328afa8681aca0f1a5f