### PR TITLE
feat: centralize template exclusion management

### DIFF
--- a/src/prompt_automation/gui/selector/service.py
+++ b/src/prompt_automation/gui/selector/service.py
@@ -27,6 +27,13 @@ from ...services.template_search import (
     resolve_shortcut,
     search,
 )
+from ...services.exclusions import (
+    load_exclusions,
+    set_exclusions,
+    add_exclusion,
+    remove_exclusion,
+    reset_exclusions,
+)
 
 
 __all__ = [
@@ -50,4 +57,9 @@ __all__ = [
     "PROMPTS_DIR",
     "load_overrides",
     "save_overrides",
+    "load_exclusions",
+    "set_exclusions",
+    "add_exclusion",
+    "remove_exclusion",
+    "reset_exclusions",
 ]

--- a/src/prompt_automation/menus/__init__.py
+++ b/src/prompt_automation/menus/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
 from ..config import PROMPTS_DIR, PROMPTS_SEARCH_PATHS
+from ..services.exclusions import parse_exclusions
 from ..renderer import (
     fill_placeholders,
     load_template,
@@ -57,15 +58,7 @@ def render_template(
     template_id = tmpl.get("id")
 
     meta = tmpl.get("metadata") if isinstance(tmpl.get("metadata"), dict) else {}
-    exclude_globals: set[str] = set()
-    try:
-        raw_ex = meta.get("exclude_globals")
-        if isinstance(raw_ex, (list, tuple)):
-            exclude_globals = {str(x).strip() for x in raw_ex if str(x).strip()}
-        elif isinstance(raw_ex, str):
-            exclude_globals = {s.strip() for s in raw_ex.split(",") if s.strip()}
-    except Exception:
-        exclude_globals = set()
+    exclude_globals: set[str] = parse_exclusions(meta.get("exclude_globals"))
 
     try:
         globals_file = PROMPTS_DIR / "globals.json"

--- a/src/prompt_automation/services/exclusions.py
+++ b/src/prompt_automation/services/exclusions.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Helpers for managing template global exclusion lists.
+
+This module centralizes parsing of the ``exclude_globals`` metadata field
+and provides convenience helpers for updating exclusion lists on disk.
+Both GUI and non-GUI components can rely on these helpers instead of
+manipulating template JSON files directly.
+"""
+
+from pathlib import Path
+from typing import Iterable, List, Optional, Set, Tuple
+import json
+
+from ..config import PROMPTS_DIR
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+
+
+def parse_exclusions(raw: object) -> Set[str]:
+    """Normalize ``raw`` into a set of exclusion strings."""
+
+    try:
+        if isinstance(raw, (list, tuple, set)):
+            return {str(x).strip() for x in raw if str(x).strip()}
+        if isinstance(raw, str):
+            items = raw.split(",") if "," in raw else [raw]
+            return {s.strip() for s in items if s.strip()}
+    except Exception:
+        pass
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers
+
+
+def _load_template(template_id: int) -> Optional[Tuple[Path, dict]]:
+    """Return ``(path, data)`` for template ``template_id`` if found."""
+
+    for p in PROMPTS_DIR.rglob("*.json"):
+        try:
+            data = json.loads(p.read_text())
+        except Exception:
+            continue
+        if data.get("id") == template_id:
+            return p, data
+    return None
+
+
+def load_exclusions(template_id: int) -> Optional[List[str]]:
+    """Return the exclusion list for ``template_id``.
+
+    Returns ``None`` when the template cannot be located.
+    """
+
+    record = _load_template(template_id)
+    if not record:
+        return None
+    _, data = record
+    meta = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+    return sorted(parse_exclusions(meta.get("exclude_globals")))
+
+
+def _write_exclusions(path: Path, data: dict, exclusions: Iterable[str]) -> None:
+    meta = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+    if not isinstance(meta, dict):
+        meta = {}
+        data["metadata"] = meta
+    cleaned = [s for s in {str(x).strip() for x in exclusions if str(x).strip()}]
+    if cleaned:
+        meta["exclude_globals"] = cleaned
+    else:
+        meta.pop("exclude_globals", None)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def set_exclusions(template_id: int, exclusions: Iterable[str]) -> bool:
+    """Replace the exclusion list for ``template_id``.
+
+    Returns ``True`` on success, ``False`` if the template is missing or the
+    file could not be written.
+    """
+
+    record = _load_template(template_id)
+    if not record:
+        return False
+    path, data = record
+    try:
+        _write_exclusions(path, data, exclusions)
+        return True
+    except Exception:
+        return False
+
+
+def add_exclusion(template_id: int, name: str) -> bool:
+    """Append ``name`` to the exclusion list for ``template_id``."""
+
+    existing = load_exclusions(template_id)
+    if existing is None:
+        return False
+    existing_set = set(existing)
+    existing_set.add(name.strip())
+    return set_exclusions(template_id, existing_set)
+
+
+def remove_exclusion(template_id: int, name: str) -> bool:
+    """Remove ``name`` from the exclusion list for ``template_id``."""
+
+    existing = load_exclusions(template_id)
+    if existing is None:
+        return False
+    existing_set = {x for x in existing if x != name.strip()}
+    return set_exclusions(template_id, existing_set)
+
+
+def reset_exclusions(template_id: int) -> bool:
+    """Clear all exclusions for ``template_id``."""
+
+    return set_exclusions(template_id, [])
+
+
+__all__ = [
+    "parse_exclusions",
+    "load_exclusions",
+    "set_exclusions",
+    "add_exclusion",
+    "remove_exclusion",
+    "reset_exclusions",
+]

--- a/tests/services/test_exclusions.py
+++ b/tests/services/test_exclusions.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import prompt_automation.services.exclusions as ex
+
+
+def _setup_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(ex, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr("prompt_automation.config.PROMPTS_DIR", tmp_path)
+
+
+def _make_template(base: Path, tid: int, exclusions=None) -> Path:
+    data = {
+        "id": tid,
+        "title": "T",
+        "style": "S",
+        "role": "assistant",
+        "template": ["hi"],
+        "placeholders": [],
+        "metadata": {},
+    }
+    if exclusions is not None:
+        data["metadata"]["exclude_globals"] = exclusions
+    path = base / f"{tid}.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_modify_exclusions(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    _make_template(tmp_path, 1, ["foo"])
+
+    assert ex.load_exclusions(1) == ["foo"]
+
+    assert ex.add_exclusion(1, "bar") is True
+    assert set(ex.load_exclusions(1)) == {"foo", "bar"}
+
+    assert ex.remove_exclusion(1, "foo") is True
+    assert ex.load_exclusions(1) == ["bar"]
+
+    assert ex.reset_exclusions(1) is True
+    assert ex.load_exclusions(1) == []
+


### PR DESCRIPTION
## Summary
- add exclusion service for parsing and persisting `exclude_globals`
- expose add/remove/reset helpers and integrate with menus and GUI
- cover exclusion modification flows with unit tests

## Testing
- `python -m pytest tests/services/test_exclusions.py -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a611e1d2c483289f74ac3b166fbd2d