### PR TITLE
feat: add Tk variable form builder

### DIFF
--- a/src/prompt_automation/services/variable_form.py
+++ b/src/prompt_automation/services/variable_form.py
@@ -1,0 +1,188 @@
+"""Tkinter form widgets for variable placeholders.
+
+This module exposes :func:`build_widget` which acts as a tiny factory for
+constructing Tk based input widgets used during variable collection.  The
+factory only performs lightweight widget construction so it can be exercised in
+unit tests with simple tkinter stubs.
+
+The returned tuple ``(constructor, binding)`` contains a callable that accepts a
+Tk *master* widget and returns the created widget and a *binding* dictionary
+exposing helpers and ``tk.Variable`` objects for retrieving or persisting the
+value entered by the user.
+
+Supported placeholder features
+------------------------------
+* Text inputs (single or multi line)
+* File path chooser with optional persistence/skip flag
+* Remembered context value persistence
+* Optional file "view" callback hook
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Tuple
+
+import tkinter as tk  # type: ignore
+from tkinter import filedialog  # type: ignore
+
+from ..variables.storage import (
+    _get_template_entry,
+    _load_overrides,
+    _save_overrides,
+    _set_template_entry,
+    get_remembered_context,
+    set_remembered_context,
+)
+
+
+@dataclass
+class _Binding:
+    """Descriptor returned by :func:`build_widget`.
+
+    Attributes are populated depending on the placeholder type but the
+    following keys are always available on the mapping representation::
+
+        get()      -> current value (``""`` when skipped)
+        persist()  -> persist any override (no-op for transient values)
+    """
+
+    get: Callable[[], str]
+    persist: Callable[[], None]
+    path_var: tk.Variable | None = None
+    skip_var: tk.Variable | None = None
+    remember_var: tk.Variable | None = None
+    view: Callable[[], None] | None = None
+
+    def as_dict(self) -> Dict[str, Any]:  # pragma: no cover - trivial
+        return {
+            "get": self.get,
+            "persist": self.persist,
+            "path_var": self.path_var,
+            "skip_var": self.skip_var,
+            "remember_var": self.remember_var,
+            "view": self.view,
+        }
+
+
+def build_widget(placeholder_spec: Dict[str, Any]) -> Tuple[Callable[[tk.Widget], tk.Widget], Dict[str, Any]]:
+    """Return ``(constructor, binding)`` for ``placeholder_spec``.
+
+    The constructor accepts a Tk *master* and returns the created widget.  The
+    accompanying binding dictionary exposes ``get``/``persist`` callables and
+    relevant ``tk.Variable`` instances to interact with the widget's state.
+    """
+
+    name = placeholder_spec.get("name", "")
+    ptype = placeholder_spec.get("type")
+    multiline = bool(placeholder_spec.get("multiline")) or ptype == "list"
+    template_id = placeholder_spec.get("template_id")
+
+    # --------------------------- text inputs ---------------------------------
+    if ptype != "file":
+        text_ref: Dict[str, tk.Widget | None] = {"widget": None}
+        var = tk.StringVar()
+        remember = bool(placeholder_spec.get("remember"))
+        if remember:
+            remembered = get_remembered_context()
+            if remembered:
+                var.set(remembered)
+        initial = placeholder_spec.get("initial")
+        if initial:
+            var.set(str(initial))
+
+        def _ctor(master: tk.Widget) -> tk.Widget:
+            if multiline:
+                widget = tk.Text(master)
+                text = var.get()
+                if text:
+                    widget.insert("1.0", text)
+                text_ref["widget"] = widget
+                return widget
+            widget = tk.Entry(master, textvariable=var)
+            text_ref["widget"] = widget
+            return widget
+
+        def _get() -> str:
+            if multiline:
+                widget = text_ref["widget"]
+                if widget is None:
+                    return ""
+                return str(widget.get("1.0", "end-1c"))
+            return str(var.get())
+
+        def _persist() -> None:
+            if remember:
+                remember_var = binding.remember_var
+                if remember_var is not None and bool(remember_var.get()):
+                    set_remembered_context(_get())
+                elif remember_var is not None and not bool(remember_var.get()):
+                    set_remembered_context(None)
+
+        remember_var = tk.BooleanVar(value=False) if remember else None
+
+        binding = _Binding(
+            get=_get,
+            persist=_persist,
+            remember_var=remember_var,
+        )
+        return _ctor, binding.as_dict()
+
+    # ------------------------- file placeholders -----------------------------
+    overrides = _load_overrides() if placeholder_spec.get("override") else {}
+    entry = (
+        _get_template_entry(overrides, template_id, name)
+        if placeholder_spec.get("override") and template_id is not None
+        else {}
+    ) or {}
+    initial_path = entry.get("path", "")
+    initial_skip = bool(entry.get("skip"))
+
+    path_var = tk.StringVar(value=initial_path)
+    skip_var = tk.BooleanVar(value=initial_skip)
+
+    def _browse() -> None:
+        fname = filedialog.askopenfilename(title=placeholder_spec.get("label", name))
+        if fname:
+            path_var.set(fname)
+            skip_var.set(False)
+
+    view_cb = placeholder_spec.get("on_view")
+    def _view() -> None:
+        if view_cb:
+            view_cb(path_var.get())
+
+    def _ctor(master: tk.Widget) -> tk.Widget:
+        frame = tk.Frame(master)
+        entry_w = tk.Entry(frame, textvariable=path_var)
+        browse_btn = tk.Button(frame, text="Browse", command=_browse)
+        skip_btn = tk.Checkbutton(frame, text="Skip", variable=skip_var)
+        # widgets are attached for potential external use but not packed to keep
+        # the constructor light-weight and headless-test friendly.
+        frame.entry = entry_w  # type: ignore[attr-defined]
+        frame.browse_btn = browse_btn  # type: ignore[attr-defined]
+        frame.skip_btn = skip_btn  # type: ignore[attr-defined]
+        if view_cb:
+            view_btn = tk.Button(frame, text="View", command=_view)
+            frame.view_btn = view_btn  # type: ignore[attr-defined]
+        return frame
+
+    def _persist() -> None:
+        if placeholder_spec.get("override") and template_id is not None:
+            payload = {"path": path_var.get(), "skip": bool(skip_var.get())}
+            _set_template_entry(overrides, template_id, name, payload)
+            _save_overrides(overrides)
+
+    def _get() -> str:
+        return "" if bool(skip_var.get()) else str(path_var.get())
+
+    binding = _Binding(
+        get=_get,
+        persist=_persist,
+        path_var=path_var,
+        skip_var=skip_var,
+        view=_view if view_cb else None,
+    )
+    return _ctor, binding.as_dict()
+
+
+__all__ = ["build_widget"]

--- a/tests/services/test_variable_form.py
+++ b/tests/services/test_variable_form.py
@@ -1,0 +1,131 @@
+import sys
+import types
+from pathlib import Path
+
+# insert src path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+# --- stub tkinter modules ---------------------------------------------------
+real_tk = sys.modules.get("tkinter")
+real_fd = sys.modules.get("tkinter.filedialog")
+
+class _Var:
+    def __init__(self, value=None):
+        self.value = value
+    def get(self):
+        return self.value
+    def set(self, v):
+        self.value = v
+
+class _Widget:
+    def __init__(self, master=None, **kw):
+        self.master = master
+        self.kw = kw
+        self.text = ""
+    def insert(self, idx, text):
+        self.text = text
+    def get(self, start=None, end=None):
+        if "textvariable" in self.kw:
+            return self.kw["textvariable"].get()
+        return self.text
+
+stub = types.ModuleType("tkinter")
+stub.Frame = _Widget
+stub.Entry = _Widget
+stub.Text = _Widget
+stub.Button = _Widget
+stub.Checkbutton = _Widget
+stub.StringVar = _Var
+stub.BooleanVar = _Var
+sys.modules["tkinter"] = stub
+
+fd_stub = types.ModuleType("filedialog")
+fd_stub.askopenfilename = lambda title=None, initialfile="": "/chosen/path"
+sys.modules["tkinter.filedialog"] = fd_stub
+
+from prompt_automation.services.variable_form import build_widget
+import prompt_automation.services.variable_form as vf
+
+# restore real tkinter modules after import
+if real_tk is not None:
+    sys.modules["tkinter"] = real_tk
+else:
+    sys.modules.pop("tkinter", None)
+if real_fd is not None:
+    sys.modules["tkinter.filedialog"] = real_fd
+else:
+    sys.modules.pop("tkinter.filedialog", None)
+
+
+# ---------------------------------------------------------------------------
+# helpers for patching storage layer
+
+
+def _setup_storage(monkeypatch, stored):
+    def fake_load():
+        return stored
+    def fake_get(data, tid, name):
+        return data.get("templates", {}).get(str(tid), {}).get(name)
+    recorded = {"set": None, "save": None}
+    def fake_set(data, tid, name, payload):
+        recorded["set"] = (tid, name, payload)
+    def fake_save(data):
+        recorded["save"] = data
+    monkeypatch.setattr(vf, "_load_overrides", fake_load)
+    monkeypatch.setattr(vf, "_get_template_entry", fake_get)
+    monkeypatch.setattr(vf, "_set_template_entry", fake_set)
+    monkeypatch.setattr(vf, "_save_overrides", fake_save)
+    return recorded
+
+
+# ---------------------------------------------------------------------------
+
+def test_text_single_line():
+    ctor, bind = build_widget({"name": "title"})
+    widget = ctor(None)
+    assert isinstance(widget, _Widget)
+    bind_obj = types.SimpleNamespace(**bind)
+    # simulate user input
+    widget.kw["textvariable"].set("hello")
+    assert bind_obj.get() == "hello"
+
+
+def test_text_multiline_remember(monkeypatch):
+    store = {"value": "old"}
+    monkeypatch.setattr(vf, "get_remembered_context", lambda: store["value"])
+    monkeypatch.setattr(vf, "set_remembered_context", lambda v: store.update(value=v))
+    ctor, bind = build_widget({"name": "context", "multiline": True, "remember": True})
+    widget = ctor(None)
+    assert widget.get() == "old"
+    widget.insert("1.0", "new text")
+    bind["remember_var"].set(True)
+    bind["persist"]()
+    assert store["value"] == "new text"
+
+
+def test_file_widget(monkeypatch):
+    stored = {"templates": {"1": {"fileph": {"path": "/remembered", "skip": False}}}}
+    calls = _setup_storage(monkeypatch, stored)
+
+    viewed = {}
+    def viewer(path):
+        viewed["path"] = path
+
+    ctor, bind = build_widget({
+        "name": "fileph",
+        "type": "file",
+        "override": True,
+        "template_id": 1,
+        "on_view": viewer,
+    })
+    ctor(None)
+    assert bind["path_var"].get() == "/remembered"
+    bind["view"]()
+    assert viewed["path"] == "/remembered"
+    bind["path_var"].set("/new/path")
+    bind["skip_var"].set(True)
+    bind["persist"]()
+    assert calls["set"] == (1, "fileph", {"path": "/new/path", "skip": True})
+    assert bind["get"]() == ""
+    bind["skip_var"].set(False)
+    assert bind["get"]() == "/new/path"


### PR DESCRIPTION
## Summary
- add `build_widget` factory for Tk variable inputs supporting text, file selection, skip flags, persistence and viewer hooks
- cover variable form builder with tkinter-stubbed tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6147c62588328b4fe49148d978004