### PR TITLE
refactor selector services

### DIFF
--- a/src/prompt_automation/gui/selector/controller.py
+++ b/src/prompt_automation/gui/selector/controller.py
@@ -1,8 +1,31 @@
-"""High-level orchestration between selector view and service."""
+"""High level orchestration between selector view and services."""
 from __future__ import annotations
-from typing import Optional
 
-from . import view, service
+from typing import Optional
+from types import SimpleNamespace
+
+from . import view
+from ...services import (
+    template_search as template_search_service,
+    multi_select as multi_select_service,
+    overrides as overrides_service,
+    exclusions as exclusions_service,
+)
+from ...config import PROMPTS_DIR
+
+
+# Bundle the individual services for injection into the view layer.  The
+# ``open_template_selector`` shim only relies on ``PROMPTS_DIR`` and
+# ``load_template_by_relative`` but we expose the full set so that
+# ``SelectorView`` can access them when instantiated directly (e.g. tests).
+service = SimpleNamespace(
+    template_search_service=template_search_service,
+    multi_select_service=multi_select_service,
+    overrides_service=overrides_service,
+    exclusions_service=exclusions_service,
+    PROMPTS_DIR=PROMPTS_DIR,
+    load_template_by_relative=template_search_service.load_template_by_relative,
+)
 
 
 def open_template_selector() -> Optional[dict]:
@@ -10,4 +33,8 @@ def open_template_selector() -> Optional[dict]:
     return view.open_template_selector(service)
 
 
-__all__ = ["open_template_selector"]
+__all__ = [
+    "open_template_selector",
+    "service",
+]
+

--- a/src/prompt_automation/gui/selector/service.py
+++ b/src/prompt_automation/gui/selector/service.py
@@ -1,3 +1,11 @@
+"""Legacy selector service facade delegating to shared services.
+
+This module historically exposed a grab bag of helper functions used by the
+selector GUI.  During the service refactor the underlying logic moved into
+dedicated modules under :mod:`prompt_automation.services`.  To preserve the
+public API we keep thin wrappers here that forward calls to the new services
+while also re-exporting those service modules for advanced callers.
+"""
 from __future__ import annotations
 
 from .model import (
@@ -6,14 +14,6 @@ from .model import (
     TemplateEntry,
     BrowserState,
 )
-from ...variables import (
-    reset_file_overrides,
-    list_file_overrides,
-    reset_single_file_override,
-    list_template_value_overrides,
-    reset_template_value_override,
-    set_template_value_override,
-)
 from ...shortcuts import (
     load_shortcuts,
     save_shortcuts,
@@ -21,19 +21,88 @@ from ...shortcuts import (
     SHORTCUT_FILE,
 )
 from ...config import PROMPTS_DIR
-from ..collector.overrides import load_overrides, save_overrides  # for options menu global reference manager
-from ...services.template_search import (
-    load_template_by_relative,
-    resolve_shortcut,
-    search,
+from ...services import (
+    template_search as template_search_service,
+    multi_select as multi_select_service,
+    overrides as overrides_service,
+    exclusions as exclusions_service,
 )
-from ...services.exclusions import (
-    load_exclusions,
-    set_exclusions,
-    add_exclusion,
-    remove_exclusion,
-    reset_exclusions,
-)
+
+
+# ---------------------------------------------------------------------------
+# Template search helpers
+
+
+def resolve_shortcut(key: str):
+    return template_search_service.resolve_shortcut(key)
+
+
+def load_template_by_relative(rel: str):
+    return template_search_service.load_template_by_relative(rel)
+
+
+def search(query: str, recursive: bool = True):
+    return template_search_service.search(query, recursive=recursive)
+
+
+# ---------------------------------------------------------------------------
+# Overrides helpers
+
+
+def reset_file_overrides():
+    return overrides_service.reset_file_overrides()
+
+
+def list_file_overrides():
+    return overrides_service.list_file_overrides()
+
+
+def reset_single_file_override(template_id: int, name: str) -> bool:
+    return overrides_service.reset_placeholder_override(template_id, name)
+
+
+def list_template_value_overrides():
+    return overrides_service.list_template_value_overrides()
+
+
+def reset_template_value_override(template_id: int, name: str) -> bool:
+    return overrides_service.reset_template_value_override_value(template_id, name)
+
+
+def set_template_value_override(template_id: int, name: str, value):
+    overrides_service.update_template_value_override(template_id, name, value)
+
+
+def load_overrides():
+    return overrides_service.load_overrides()
+
+
+def save_overrides(overrides):
+    overrides_service.save_overrides(overrides)
+
+
+# ---------------------------------------------------------------------------
+# Exclusions helpers
+
+
+def load_exclusions(template_id: int):
+    return exclusions_service.load_exclusions(template_id)
+
+
+def set_exclusions(template_id: int, exclusions):
+    return exclusions_service.set_exclusions(template_id, exclusions)
+
+
+def add_exclusion(template_id: int, name: str):
+    return exclusions_service.add_exclusion(template_id, name)
+
+
+def remove_exclusion(template_id: int, name: str):
+    return exclusions_service.remove_exclusion(template_id, name)
+
+
+def reset_exclusions(template_id: int):
+    return exclusions_service.reset_exclusions(template_id)
 
 
 __all__ = [
@@ -51,6 +120,10 @@ __all__ = [
     "save_shortcuts",
     "renumber_templates",
     "SHORTCUT_FILE",
+    "template_search_service",
+    "multi_select_service",
+    "overrides_service",
+    "exclusions_service",
     "resolve_shortcut",
     "load_template_by_relative",
     "search",
@@ -63,3 +136,4 @@ __all__ = [
     "remove_exclusion",
     "reset_exclusions",
 ]
+

--- a/src/prompt_automation/gui/selector/view/orchestrator.py
+++ b/src/prompt_automation/gui/selector/view/orchestrator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from ....services.multi_select import merge_templates
 from .preview import open_preview
 from .overrides import manage_overrides
 from .exclusions import edit_exclusions
@@ -26,7 +25,7 @@ class SelectorView:
     def search(self, query: str):
         """Delegate search to the service respecting recursive toggle."""
         recursive = not self.non_recursive
-        return self.service.search(query, recursive=recursive)
+        return self.service.template_search_service.search(query, recursive=recursive)
 
     # --- Multi-select ---------------------------------------------------
     def select_multi(self, template: dict) -> None:
@@ -38,7 +37,7 @@ class SelectorView:
 
     def finish_multi(self) -> Optional[dict]:
         """Combine selected templates into a synthetic multi template."""
-        combined = merge_templates(self.multi_selected)
+        combined = self.service.multi_select_service.merge_templates(self.multi_selected)
         self.multi_selected = []
         return combined
 
@@ -47,10 +46,10 @@ class SelectorView:
         open_preview(parent, entry)
 
     def manage_overrides(self, root) -> None:
-        manage_overrides(root, self.service)
+        manage_overrides(root, self.service.overrides_service)
 
     def edit_exclusions(self, root) -> None:
-        edit_exclusions(root, self.service)
+        edit_exclusions(root, self.service.exclusions_service)
 
     # --- GUI open placeholder -------------------------------------------
     def open(self, embedded: bool = False, parent=None):  # pragma: no cover - GUI heavy

--- a/tests/gui/selector/test_service_delegation.py
+++ b/tests/gui/selector/test_service_delegation.py
@@ -1,0 +1,29 @@
+def test_search_delegates(monkeypatch):
+    from prompt_automation.gui.selector import service
+
+    marker = object()
+
+    def fake_search(q, recursive=True):
+        return [marker, q, recursive]
+
+    monkeypatch.setattr(service.template_search_service, "search", fake_search)
+    assert service.search("hi", recursive=False) == [marker, "hi", False]
+
+
+def test_overrides_delegate(monkeypatch):
+    from prompt_automation.gui.selector import service
+
+    marker = [(1, "name", {})]
+    monkeypatch.setattr(
+        service.overrides_service, "list_file_overrides", lambda: marker
+    )
+    assert service.list_file_overrides() is marker
+
+
+def test_exclusions_delegate(monkeypatch):
+    from prompt_automation.gui.selector import service
+
+    marker = ["a"]
+    monkeypatch.setattr(service.exclusions_service, "load_exclusions", lambda tid: marker)
+    assert service.load_exclusions(5) is marker
+

--- a/tests/gui/selector/test_view_behavior.py
+++ b/tests/gui/selector/test_view_behavior.py
@@ -51,9 +51,22 @@ class DummyService:
     def __init__(self):
         self.calls = []
 
-    def search(self, query: str, recursive: bool = True):
-        self.calls.append((query, recursive))
-        return []
+        def _search(query: str, recursive: bool = True):
+            self.calls.append((query, recursive))
+            return []
+
+        def _merge(templates):
+            combined = []
+            for tmpl in templates:
+                combined.extend(tmpl.get("template", []))
+            return {
+                "template": combined,
+                "title": f"Multi ({len(templates)})",
+                "style": "multi",
+            }
+
+        self.template_search_service = types.SimpleNamespace(search=_search)
+        self.multi_select_service = types.SimpleNamespace(merge_templates=_merge)
 
 
 def test_recursive_toggle_behavior():


### PR DESCRIPTION
## Summary
- delegate selector controller to new template_search, multi_select, overrides and exclusions services
- update selector view to use injected services for searching, multi-merge, overrides and exclusions dialogs
- add tests verifying service delegation and preserve legacy behaviour

## Testing
- `pytest tests/gui/selector -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a616493c308328b896ebc364cc0bfd