### PR TITLE
Wire multi-select combine and add rendering regression tests

### DIFF
--- a/src/prompt_automation/gui/single_window/frames/select.py
+++ b/src/prompt_automation/gui/single_window/frames/select.py
@@ -12,7 +12,7 @@ from typing import Dict, Any
 from ....config import PROMPTS_DIR
 from ....renderer import load_template
 from ....services.template_search import list_templates, resolve_shortcut
-from ....services.multi_select import merge_templates
+from ....services import multi_select as multi_select_service
 
 
 def build(app) -> Any:  # pragma: no cover - Tk runtime
@@ -76,7 +76,7 @@ def build(app) -> Any:  # pragma: no cover - Tk runtime
                 state["preview"] = ""
 
         def combine():
-            tmpl = merge_templates(state["selected"])
+            tmpl = multi_select_service.merge_templates(state["selected"])
             if tmpl:
                 app.advance_to_collect(tmpl)
             return tmpl
@@ -154,7 +154,7 @@ def build(app) -> Any:  # pragma: no cover - Tk runtime
             status.set("Select at least two templates")
             return "break"
         loaded = [load_template(rel_map[i]) for i in sel]
-        tmpl = merge_templates(loaded)
+        tmpl = multi_select_service.merge_templates(loaded)
         if tmpl:
             app.advance_to_collect(tmpl)
         else:

--- a/tests/gui/single_window/test_select_frame.py
+++ b/tests/gui/single_window/test_select_frame.py
@@ -90,7 +90,7 @@ def test_multi_select_combination(monkeypatch):
             combined.extend(tmpl.get("template", []))
         return {"template": combined}
 
-    monkeypatch.setattr(select, "merge_templates", fake_merge)
+    monkeypatch.setattr(select.multi_select_service, "merge_templates", fake_merge)
     received = []
     app = types.SimpleNamespace(root=object(), advance_to_collect=lambda data: received.append(data))
 

--- a/tests/services/test_multi_select.py
+++ b/tests/services/test_multi_select.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import prompt_automation.services.multi_select as ms
 import prompt_automation.services.template_search as ts
 from prompt_automation.shortcuts import save_shortcuts
+from prompt_automation.menus import render_template
 
 
 def _make_template(base: Path, rel: str, lines: list[str]) -> Path:
@@ -66,3 +67,29 @@ def test_merge_shortcut_keys(tmp_path, monkeypatch):
     })
     merged = ms.merge_shortcuts(["1", "2", "1"])
     assert merged["template"] == ["Alpha", "Beta"]
+
+
+def test_merged_render_matches_sequential():
+    t1 = {
+        "id": 1,
+        "title": "A",
+        "style": "Test",
+        "template": ["Hello {{x}}"],
+        "placeholders": [{"name": "x"}],
+    }
+    t2 = {
+        "id": 2,
+        "title": "B",
+        "style": "Test",
+        "template": ["Bye {{y}}"],
+        "placeholders": [{"name": "y"}],
+    }
+    legacy = "\n".join(
+        [
+            render_template(t1, {"x": "one"}),
+            render_template(t2, {"y": "two"}),
+        ]
+    )
+    combined = ms.merge_templates([t1, t2])
+    merged = render_template(combined, {"x": "one", "y": "two"})
+    assert merged == legacy


### PR DESCRIPTION
## Summary
- Use `multi_select_service.merge_templates` in single-window selector so Combine sends a synthetic template to the collect stage
- Add regression test ensuring merged templates render the same as sequential rendering
- Adjust tests to patch the service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61c0dfb9c8328bceea937a69c1781