### PR TITLE
Handle single-window stage errors with dialog and logging

### DIFF
--- a/src/prompt_automation/gui/controller.py
+++ b/src/prompt_automation/gui/controller.py
@@ -25,7 +25,7 @@ from ..errorlog import get_logger
 from .selector import open_template_selector
 from .collector import collect_variables_gui
 from .review_window import review_output_gui
-from .single_window import SingleWindowApp
+from . import single_window
 from .file_append import _append_to_files
 
 
@@ -65,7 +65,7 @@ class PromptGUI:
                 self._log.info("Starting GUI workflow (EXPERIMENTAL single-window mode)")
                 single_started = False
                 try:
-                    app = SingleWindowApp(); single_started = True
+                    app = single_window.SingleWindowApp(); single_started = True
                     final_text, var_map = app.run()
                     template = getattr(app, "template", None)
                     if template and final_text is not None and var_map is not None:

--- a/src/prompt_automation/gui/single_window/__init__.py
+++ b/src/prompt_automation/gui/single_window/__init__.py
@@ -1,13 +1,28 @@
 """Single-window GUI package."""
 from __future__ import annotations
 
-from .controller import SingleWindowApp
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .controller import SingleWindowApp as _SWA
 
 
-def run() -> tuple[None, None]:  # pragma: no cover - thin shim
+def _load() -> "_SWA":
+    from .controller import SingleWindowApp as _App
+
+    return _App
+
+
+def run() -> Tuple[None, None]:  # pragma: no cover - thin shim
     """Convenience shim to mirror legacy ``single_window.run`` behavior."""
-    app = SingleWindowApp()
+    app = _load()()
     return app.run()
 
 
 __all__ = ["SingleWindowApp", "run"]
+
+
+def __getattr__(name: str):  # pragma: no cover - simple proxy
+    if name == "SingleWindowApp":
+        return _load()
+    raise AttributeError(name)

--- a/tests/z_single_window/test_controller.py
+++ b/tests/z_single_window/test_controller.py
@@ -1,0 +1,110 @@
+import sys
+import types
+from pathlib import Path
+import importlib
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+def _install_tk(monkeypatch):
+    """Install a minimal tkinter stub capturing messagebox calls."""
+    calls = []
+    class DummyTk:
+        def __init__(self):
+            self.children = {}
+            self._geom = "111x222"
+        def title(self, *a, **k):
+            pass
+        def geometry(self, g=None):
+            if g:
+                self._geom = g
+            return self._geom
+        def minsize(self, *a, **k):
+            pass
+        def resizable(self, *a, **k):
+            pass
+        def protocol(self, *a, **k):
+            pass
+        def update_idletasks(self):
+            pass
+        def winfo_geometry(self):
+            return self._geom
+        def winfo_exists(self):
+            return True
+        def quit(self):
+            pass
+        def destroy(self):
+            pass
+    stub = types.ModuleType("tkinter")
+    stub.Tk = DummyTk
+    stub.messagebox = types.SimpleNamespace(showerror=lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setitem(sys.modules, "tkinter", stub)
+    return stub, calls
+
+
+def _load_controller(monkeypatch):
+    fake_vf = types.SimpleNamespace(build_widget=lambda spec: (lambda m: None, {}))
+    orig_vf = sys.modules.get("prompt_automation.services.variable_form")
+    sys.modules["prompt_automation.services.variable_form"] = fake_vf
+    module = importlib.import_module("prompt_automation.gui.single_window.controller")
+    mods = [
+        "prompt_automation.gui.single_window.controller",
+        "prompt_automation.gui.single_window.frames.select",
+        "prompt_automation.gui.single_window.frames.collect",
+        "prompt_automation.gui.single_window.frames.review",
+        "prompt_automation.gui.single_window.frames",
+    ]
+    def cleanup():
+        for m in mods:
+            sys.modules.pop(m, None)
+        if orig_vf is not None:
+            sys.modules["prompt_automation.services.variable_form"] = orig_vf
+        else:
+            sys.modules.pop("prompt_automation.services.variable_form", None)
+    return module, cleanup
+
+
+def test_stage_swap_persists_geometry(monkeypatch):
+    _install_tk(monkeypatch)
+    controller, cleanup = _load_controller(monkeypatch)
+    saves = []
+    monkeypatch.setattr(controller, "save_geometry", lambda g: saves.append(g))
+    monkeypatch.setattr(controller.select, "build", lambda app: None)
+    monkeypatch.setattr(controller.collect, "build", lambda app, t: None)
+    monkeypatch.setattr(controller.review, "build", lambda app, t, v: None)
+    try:
+        app = controller.SingleWindowApp()
+        app.start()
+        app.advance_to_collect({})
+        app.advance_to_review({})
+        app.back_to_select()
+        assert len(saves) == 4
+    finally:
+        cleanup()
+
+
+def test_service_exception_triggers_dialog_and_log(monkeypatch):
+    stub, calls = _install_tk(monkeypatch)
+    controller, cleanup = _load_controller(monkeypatch)
+    logs = []
+    class StubLogger:
+        def error(self, msg, *args, **kwargs):
+            logs.append({"msg": msg, "args": args, "kwargs": kwargs})
+    monkeypatch.setattr(controller, "get_logger", lambda name: StubLogger())
+    saves = []
+    monkeypatch.setattr(controller, "save_geometry", lambda g: saves.append(g))
+    monkeypatch.setattr(controller.select, "build", lambda app: None)
+    def bad_collect(app, t):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(controller.collect, "build", bad_collect)
+    try:
+        app = controller.SingleWindowApp()
+        app.start()
+        with pytest.raises(RuntimeError):
+            app.advance_to_collect({})
+        assert calls and "boom" in calls[0][0][1]
+        assert logs and logs[0]["kwargs"].get("exc_info")
+        assert len(saves) == 1
+    finally:
+        cleanup()


### PR DESCRIPTION
## Summary
- add try/except around single-window stage transitions, logging stack traces and showing message boxes
- persist window geometry after each successful stage swap
- cover controller error handling and persistence in new tests

## Testing
- `pytest tests/z_single_window/test_controller.py -q`
- `pytest -q` *(fails: Too early to create variable: no default root window)*

------
https://chatgpt.com/codex/tasks/task_e_68a626379d0c832882671675e454207b