### PR TITLE
docs: document single-window default and services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## Unreleased
-_No pending changes; preparing for next cycle._
+- Unified single-window UI now matches legacy feature set and is the default
+  experience. Set `PROMPT_AUTOMATION_FORCE_LEGACY=1` to restore the old
+  multi-window dialogs.
+- Documented modular service layer (`template_search`, `multi_select`,
+  `variable_form`, `overrides`, `exclusions`).
 
 ## 0.4.4 - 2025-08-18
 Comprehensive GUI refactor + quality-of-life enhancements, consolidating prior selector modernization and adding new safety / clarity features.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prompt-automation
 
-**prompt-automation** is a keyboard driven prompt launcher designed for absolute beginners. With a single hotkey you can choose a template, fill in any placeholders and copy the result to your clipboard for manual pasting.
+**prompt-automation** is a keyboard driven prompt launcher designed for absolute beginners. With a single hotkey you can choose a template, fill in any placeholders and copy the result to your clipboard for manual pasting. The selector, collector and review now run in a unified single window. Set `PROMPT_AUTOMATION_FORCE_LEGACY=1` before launching to force the older multi-window flow.
 
 Recent feature highlights:
 - Default value helper: input dialogs show a truncated hint of each placeholder's default (with a [view] popup for long defaults) and empty submissions now fall back to that default at render time.
@@ -520,6 +520,16 @@ project/
 │       ├── prompts/    # Contains styles/basic/01_basic.json
 │       └── ...         # Application modules
 ```
+
+## Services
+
+The GUI now delegates work to a small service layer useful for extensions and automation:
+
+- `template_search` – walk the prompts tree and resolve numeric shortcuts.
+- `multi_select` – build synthetic combined templates from marked items.
+- `variable_form` – construct placeholder widgets for variable collection.
+- `overrides` – manage persisted placeholder values and file paths.
+- `exclusions` – parse `exclude_globals` metadata.
 
 Enjoy!
 

--- a/docs/HOTKEYS.md
+++ b/docs/HOTKEYS.md
@@ -3,6 +3,10 @@
 This project provides platform-specific scripts for launching `prompt-automation` with a keyboard shortcut.
 The default key combination is **Ctrl+Shift+J**. Run `prompt-automation --assign-hotkey` to change it at any time.
 
+The launcher now uses a unified single-window interface for selection, variable
+collection, and review. Set `PROMPT_AUTOMATION_FORCE_LEGACY=1` before launching
+if you prefer the older multi-window dialogs.
+
 ## Windows
 1. Run `install/install.ps1` from PowerShell. The script installs dependencies, checks for AutoHotkey v2, and copies `windows.ahk` to your Startup folder.
 2. Verify registration with:

--- a/docs/VARIABLES_REFERENCE.md
+++ b/docs/VARIABLES_REFERENCE.md
@@ -5,6 +5,10 @@ Comprehensive guide to every kind of variable (placeholder) and global control p
 
 Authoritative, example‑rich guide to every kind of variable (placeholder) and global control point used by `prompt-automation`: how values are collected, transformed, persisted, excluded, and rendered. Each section now includes practical JSON/body snippets plus rendered outputs for clarity.
 
+Variable collection and review now occur in a single window. Set
+`PROMPT_AUTOMATION_FORCE_LEGACY=1` before launching to restore the
+multi-window dialogs.
+
 ---
 ## 1. High-Level Flow
 
@@ -349,6 +353,7 @@ Edge cases:
 | PROMPT_AUTOMATION_TRIM_BLANKS | Force enable/disable trimming (`0/false` disables) | Auto (true) |
 | PROMPT_AUTOMATION_AUTO_UPDATE | Toggle background updater | Enabled |
 | PROMPT_AUTOMATION_MANIFEST_AUTO | Toggle manifest auto-apply | Enabled |
+| PROMPT_AUTOMATION_FORCE_LEGACY | Revert to legacy multi-window GUI | Disabled |
 
 ---
 ## 17. Metadata Keys
@@ -424,7 +429,19 @@ Testing guidance:
 * Use parametrized tests for placeholder type formatting permutations.
 
 ---
-## 22. Related Docs
+## 22. Services
+
+Internally, variable handling is powered by modular service helpers which can be
+reused in custom tooling:
+
+- `template_search`
+- `multi_select`
+- `variable_form`
+- `overrides`
+- `exclusions`
+
+---
+## 23. Related Docs
 
 * Codebase overview: `docs/CODEBASE_REFERENCE.md`
 * Installation issues: `docs/INSTALLATION_TROUBLESHOOTING.md`


### PR DESCRIPTION
## Summary
- note single-window interface default and fallback env var
- document new service modules
- update hotkeys and variables reference

## Testing
- `pytest`
- `python -m build` *(fails: No module named build; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a62e20c0dc8328b5ad7b4fe0bc468e