### PR TITLE
Default single-window GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Unified single-window UI now matches legacy feature set and is the default
   experience. Set `PROMPT_AUTOMATION_FORCE_LEGACY=1` to restore the old
   multi-window dialogs.
+- Removed experimental `PROMPT_AUTOMATION_SINGLE_WINDOW` toggle.
 - Documented modular service layer (`template_search`, `multi_select`,
   `variable_form`, `overrides`, `exclusions`).
 

--- a/src/prompt_automation/gui/controller.py
+++ b/src/prompt_automation/gui/controller.py
@@ -1,19 +1,10 @@
 """High level GUI controller.
 
-Recent refactor introduced an experimental *single-window* workflow implemented
-in :mod:`prompt_automation.gui.single_window`. The current single-window
-implementation intentionally uses placeholder frame builders (see
-``single_window/frames/*.py``) that do **not** create real widgets yet. This
-results in a blank / empty window (only a bare Tk root) exactly like the user
-reported.
-
-To avoid shipping a non-functional GUI we gate the experimental path behind the
-environment variable ``PROMPT_AUTOMATION_SINGLE_WINDOW=1`` and fall back to the
-fully functional legacy multi-step GUI (template selector -> variable
-collection -> review window) by default.
-
-Set ``PROMPT_AUTOMATION_SINGLE_WINDOW=1`` to re-enable the new flow while it is
-under development.
+The project now ships a unified *single-window* workflow implemented in
+``prompt_automation.gui.single_window``. This flow matches the feature set of
+the legacy multi-step GUI and is the default experience. Set the environment
+variable ``PROMPT_AUTOMATION_FORCE_LEGACY=1`` to revert to the legacy
+multi-window dialogs.
 """
 from __future__ import annotations
 
@@ -60,9 +51,9 @@ class PromptGUI:
             return
 
         try:
-            if os.environ.get("PROMPT_AUTOMATION_SINGLE_WINDOW") == "1":
-                # --- Experimental single-window path ---------------------------------
-                self._log.info("Starting GUI workflow (EXPERIMENTAL single-window mode)")
+            if os.environ.get("PROMPT_AUTOMATION_FORCE_LEGACY") != "1":
+                # --- Single-window path (default) ------------------------------------
+                self._log.info("Starting GUI workflow (single-window mode)")
                 single_started = False
                 try:
                     app = single_window.SingleWindowApp(); single_started = True
@@ -85,7 +76,7 @@ class PromptGUI:
                         return
                     # Fall through to legacy flow below
 
-            # --- Legacy multi-window flow (default) ----------------------------------
+            # --- Legacy multi-window flow (forced or fallback) -----------------------
             self._log.info("Starting GUI workflow (legacy multi-window mode)")
             template = open_template_selector()
             if template:

--- a/src/prompt_automation/gui/selector/view/__init__.py
+++ b/src/prompt_automation/gui/selector/view/__init__.py
@@ -9,8 +9,7 @@ caused the runtime error: ``open_template_selector() takes 0 positional args``.
 
 We restore compatibility by re‑implementing a lightweight template picker UI
 that accepts the service module argument. This is intentionally minimal but
-functional so legacy multi-window mode works while the new single-window flow
-evolves.
+functional for the legacy multi-window mode retained as a fallback.
 """
 from __future__ import annotations
 

--- a/tests/gui/test_prompt_gui_default.py
+++ b/tests/gui/test_prompt_gui_default.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import prompt_automation.gui.controller as controller
+
+def _install_tk(monkeypatch):
+    stub = types.ModuleType("tkinter")
+    class DummyTk:
+        def __init__(self):
+            pass
+        def mainloop(self):
+            pass
+        def withdraw(self):
+            pass
+    stub.Tk = DummyTk
+    stub.__path__ = []  # mark as package for submodule imports
+    monkeypatch.setitem(sys.modules, "tkinter", stub)
+    for name in ("ttk", "filedialog", "messagebox", "simpledialog"):
+        monkeypatch.setitem(sys.modules, f"tkinter.{name}", types.ModuleType(name))
+
+
+def _patch_updates(monkeypatch):
+    monkeypatch.setattr(controller.updater, "check_for_update", lambda: None)
+    monkeypatch.setattr(controller.update, "check_and_prompt", lambda: None)
+
+
+def test_single_window_is_default(monkeypatch):
+    _install_tk(monkeypatch)
+    _patch_updates(monkeypatch)
+    called = {"single": False, "legacy": False}
+
+    class DummyApp:
+        def run(self):
+            called["single"] = True
+            return None, None
+
+    monkeypatch.setattr(controller.single_window, "SingleWindowApp", DummyApp)
+    monkeypatch.setattr(controller, "open_template_selector", lambda: called.__setitem__("legacy", True))
+
+    gui = controller.PromptGUI()
+    gui.run()
+    assert called["single"] and not called["legacy"]
+
+
+def test_force_legacy_env(monkeypatch):
+    _install_tk(monkeypatch)
+    _patch_updates(monkeypatch)
+    monkeypatch.setenv("PROMPT_AUTOMATION_FORCE_LEGACY", "1")
+    called = {"single": False, "legacy": False}
+
+    class DummyApp:
+        def run(self):
+            called["single"] = True
+            return None, None
+
+    monkeypatch.setattr(controller.single_window, "SingleWindowApp", DummyApp)
+    monkeypatch.setattr(controller, "open_template_selector", lambda: called.__setitem__("legacy", True))
+
+    gui = controller.PromptGUI()
+    gui.run()
+    assert called["legacy"] and not called["single"]


### PR DESCRIPTION
## Summary
- make unified single-window GUI the default and drop PROMPT_AUTOMATION_SINGLE_WINDOW gate
- allow reverting to legacy multi-window UI via PROMPT_AUTOMATION_FORCE_LEGACY
- add tests for default single-window path and forced legacy path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6304df0d883289233f488aad554af