### PR TITLE
Centralize GUI error handling via helper

### DIFF
--- a/src/prompt_automation/gui/controller.py
+++ b/src/prompt_automation/gui/controller.py
@@ -18,6 +18,7 @@ from .collector import collect_variables_gui
 from .review_window import review_output_gui
 from . import single_window
 from .file_append import _append_to_files
+from .error_dialogs import show_error
 
 
 class PromptGUI:
@@ -91,11 +92,10 @@ class PromptGUI:
             self._log.error("GUI workflow failed: %s", e, exc_info=True)
             try:
                 import tkinter as tk
-                from tkinter import messagebox
 
                 root = tk.Tk()
                 root.withdraw()
-                messagebox.showerror(
+                show_error(
                     "Error",
                     f"An error occurred in the GUI:\n\n{e}\n\nCheck logs for details.",
                 )

--- a/src/prompt_automation/gui/error_dialogs.py
+++ b/src/prompt_automation/gui/error_dialogs.py
@@ -1,0 +1,24 @@
+"""Central helpers for displaying GUI error dialogs.
+
+Wraps ``tkinter.messagebox.showerror`` to avoid repeated imports across
+modules. Failures are ignored so code remains safe in headless test
+runs or minimal environments without Tk support.
+"""
+from __future__ import annotations
+
+
+def show_error(title: str, message: str) -> None:
+    """Best-effort wrapper around ``messagebox.showerror``."""
+    try:
+        from tkinter import messagebox
+    except Exception:
+        return
+    try:
+        messagebox.showerror(title, message)
+    except Exception:
+        # Error dialogs should never raise further exceptions; simply
+        # swallow any issues so callers don't need additional guards.
+        pass
+
+
+__all__ = ["show_error"]

--- a/src/prompt_automation/gui/selector/view/preview.py
+++ b/src/prompt_automation/gui/selector/view/preview.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 def open_preview(parent: "tk.Tk", entry: TemplateEntry) -> None:
     """Display a read-only preview of a template."""
     import tkinter as tk
-    from tkinter import messagebox
     from ..fonts import get_display_font
+    from ...error_dialogs import show_error
 
     try:
         tmpl = entry.data
@@ -30,4 +30,4 @@ def open_preview(parent: "tk.Tk", entry: TemplateEntry) -> None:
         preview.transient(parent)
         preview.grab_set()
     except Exception as e:  # pragma: no cover - GUI error path
-        messagebox.showerror("Preview Error", str(e))
+        show_error("Preview Error", str(e))

--- a/src/prompt_automation/gui/single_window/controller.py
+++ b/src/prompt_automation/gui/single_window/controller.py
@@ -22,6 +22,7 @@ from ...services import exclusions as exclusions_service
 from ...services import overrides as selector_service
 from ..selector import view as selector_view_module
 from .. import options_menu
+from ..error_dialogs import show_error
 
 
 class SingleWindowApp:
@@ -72,9 +73,7 @@ class SingleWindowApp:
             select.build(self)
         except Exception as e:
             self._log.error("Template selection failed: %s", e, exc_info=True)
-            from tkinter import messagebox
-
-            messagebox.showerror("Error", f"Failed to open template selector:\n{e}")
+            show_error("Error", f"Failed to open template selector:\n{e}")
             raise
         else:
             try:
@@ -90,9 +89,7 @@ class SingleWindowApp:
             collect.build(self, template)
         except Exception as e:
             self._log.error("Variable collection failed: %s", e, exc_info=True)
-            from tkinter import messagebox
-
-            messagebox.showerror("Error", f"Failed to collect variables:\n{e}")
+            show_error("Error", f"Failed to collect variables:\n{e}")
             raise
         else:
             try:
@@ -111,9 +108,7 @@ class SingleWindowApp:
             review.build(self, self.template, variables)
         except Exception as e:
             self._log.error("Review window failed: %s", e, exc_info=True)
-            from tkinter import messagebox
-
-            messagebox.showerror("Error", f"Failed to open review window:\n{e}")
+            show_error("Error", f"Failed to open review window:\n{e}")
             raise
         else:
             try:
@@ -131,9 +126,7 @@ class SingleWindowApp:
                 exclusions_dialog(self.root, exclusions_service)  # type: ignore[misc]
         except Exception as e:
             self._log.error("Exclusions editor failed: %s", e, exc_info=True)
-            from tkinter import messagebox
-
-            messagebox.showerror("Error", f"Failed to edit exclusions:\n{e}")
+            show_error("Error", f"Failed to edit exclusions:\n{e}")
 
     def finish(self, final_text: str) -> None:
         self.final_text = final_text

--- a/tests/gui/selector/test_preview_errors.py
+++ b/tests/gui/selector/test_preview_errors.py
@@ -1,0 +1,24 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from prompt_automation.gui.selector.view import preview
+from prompt_automation.gui import error_dialogs
+
+
+def test_open_preview_error_triggers_helper(monkeypatch):
+    calls = []
+    monkeypatch.setattr(error_dialogs, "show_error", lambda *a, **k: calls.append((a, k)))
+    tk_stub = types.ModuleType("tkinter")
+    tk_stub.Toplevel = lambda parent: (_ for _ in ()).throw(RuntimeError("boom"))
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    font_stub = types.ModuleType("fonts")
+    font_stub.get_display_font = lambda *a, **k: ("Arial", 10)
+    monkeypatch.setitem(sys.modules, "prompt_automation.gui.selector.fonts", font_stub)
+    entry = types.SimpleNamespace(data={})
+    preview.open_preview(object(), entry)
+    assert calls and "boom" in calls[0][0][1]


### PR DESCRIPTION
## Summary
- Add `show_error` helper wrapping `tkinter.messagebox.showerror`
- Use centralized helper in controller and preview modules
- Test GUI error paths by stubbing helper and simulating preview failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a84b757550832894565c2a1f237627