### PR TITLE
feat(gui): add shortcut help dialog

### DIFF
--- a/src/prompt_automation/gui/single_window/controller.py
+++ b/src/prompt_automation/gui/single_window/controller.py
@@ -23,6 +23,7 @@ from ...services import overrides as selector_service
 from ..selector import view as selector_view_module
 from .. import options_menu
 from ..error_dialogs import show_error
+from ...shortcuts import load_shortcuts
 
 
 class SingleWindowApp:
@@ -44,6 +45,9 @@ class SingleWindowApp:
         )
         for seq, func in self._accelerators.items():
             self.root.bind(seq, lambda e, f=func: (f(), "break"))
+
+        # Global shortcut help (F1)
+        self.root.bind("<F1>", lambda e: (self._show_shortcuts(), "break"))
 
         self.template: Optional[Dict[str, Any]] = None
         self.variables: Optional[Dict[str, Any]] = None
@@ -127,6 +131,18 @@ class SingleWindowApp:
         except Exception as e:
             self._log.error("Exclusions editor failed: %s", e, exc_info=True)
             show_error("Error", f"Failed to edit exclusions:\n{e}")
+
+    def _show_shortcuts(self) -> None:
+        """Display configured template shortcuts in a simple dialog."""
+        from tkinter import messagebox
+
+        mapping = load_shortcuts()
+        if not mapping:
+            msg = "No shortcuts configured."
+        else:
+            lines = [f"{k}: {v}" for k, v in sorted(mapping.items())]
+            msg = "\n".join(lines)
+        messagebox.showinfo("Shortcuts", msg)
 
     def finish(self, final_text: str) -> None:
         self.final_text = final_text

--- a/tests/gui/single_window/test_flow_parity.py
+++ b/tests/gui/single_window/test_flow_parity.py
@@ -16,6 +16,7 @@ def _install_tk(monkeypatch):
         def __init__(self):
             self.children = {}
             self._geom = "200x100"
+            self.bound = {}
 
         def title(self, *_a, **_k):
             pass
@@ -51,6 +52,9 @@ def _install_tk(monkeypatch):
 
         def mainloop(self):
             pass
+
+        def bind(self, seq, func):
+            self.bound[seq] = func
 
     stub = types.ModuleType("tkinter")
     stub.Tk = DummyTk

--- a/tests/z_single_window/test_controller.py
+++ b/tests/z_single_window/test_controller.py
@@ -161,3 +161,23 @@ def test_options_menu_accelerators_bound(monkeypatch):
         assert result == (None, "break")
     finally:
         cleanup()
+
+
+def test_f1_binding_opens_shortcuts_dialog(monkeypatch):
+    tk = _install_tk(monkeypatch)
+    controller, cleanup = _load_controller(monkeypatch)
+    called = []
+
+    def fake_configure(root, *a, **k):
+        return {}
+
+    monkeypatch.setattr(controller.options_menu, "configure_options_menu", fake_configure)
+    monkeypatch.setattr(controller, "load_shortcuts", lambda: {"1": "a.json"})
+    tk.messagebox.showinfo = lambda title, msg: called.append((title, msg))
+    try:
+        app = controller.SingleWindowApp()
+        assert "<F1>" in app.root.bound
+        app.root.bound["<F1>"](None)
+        assert called and called[0][0] == "Shortcuts"
+    finally:
+        cleanup()


### PR DESCRIPTION
## Summary
- bind F1 in the single-window controller to show a list of template shortcuts
- read shortcut mapping from the shared `shortcuts` module to keep docs and UI in sync
- cover shortcut help with tests and update Tk test stubs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84d54f78883288841c0351f5c57b3