### PR TITLE
Add uninstall detection and CLI tests

### DIFF
--- a/tests/test_uninstall_cli.py
+++ b/tests/test_uninstall_cli.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import json
+
+
+def _find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / "pyproject.toml").exists():
+            return d
+    return start.parent
+
+
+_repo_root = _find_repo_root(Path(__file__).resolve())
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from prompt_automation.cli.controller import PromptCLI
+from prompt_automation.uninstall.artifacts import Artifact
+from prompt_automation.uninstall import executor
+
+
+def test_uninstall_cli_flow(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("UNINSTALL_FEATURE_FLAG", "1")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    art_path = tmp_path / "dummy.txt"
+    art_path.write_text("payload")
+    artifact = Artifact("dummy", "file", art_path, purge_candidate=True)
+
+    def detector(_platform):
+        return [artifact] if art_path.exists() else []
+
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [detector])
+    cli = PromptCLI()
+
+    cli.main(["uninstall", "--purge-data", "--force", "--dry-run", "--json", "--platform", "win32"])
+    out1 = capsys.readouterr().out
+    data1 = json.loads(out1)
+    assert art_path.exists()
+    assert data1["removed"][0]["status"] == "planned"
+
+    cli.main(["uninstall", "--purge-data", "--force", "--json", "--platform", "win32"])
+    out2 = capsys.readouterr().out
+    data2 = json.loads(out2)
+    assert not art_path.exists()
+    assert data2["removed"][0]["status"] == "removed"
+
+    cli.main(["uninstall", "--purge-data", "--force", "--json", "--platform", "win32"])
+    out3 = capsys.readouterr().out
+    data3 = json.loads(out3)
+    assert data3["removed"] == []

--- a/tests/test_uninstall_plan.py
+++ b/tests/test_uninstall_plan.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+import os
+
+
+def _find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / "pyproject.toml").exists():
+            return d
+    return start.parent
+
+
+_repo_root = _find_repo_root(Path(__file__).resolve())
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from prompt_automation.uninstall import detectors, executor
+from prompt_automation.uninstall.artifacts import Artifact
+from prompt_automation.cli.controller import UninstallOptions
+
+
+def test_artifact_detection_and_platforms(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    (tmp_path / ".config/prompt-automation").mkdir(parents=True)
+    (tmp_path / ".cache/prompt-automation").mkdir(parents=True)
+    (tmp_path / ".config/prompt-automation/logs").mkdir(parents=True)
+    data_arts = detectors.detect_data_dirs(platform="linux")
+    assert {a.id for a in data_arts} == {"config-dir", "cache-dir", "log-dir"}
+    assert all(a.purge_candidate for a in data_arts)
+
+    scripts = tmp_path / "Scripts"
+    scripts.mkdir()
+    (scripts / "prompt-automation.exe").touch()
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    win_arts = detectors.detect_symlink_wrappers(platform="win32")
+    assert win_arts and win_arts[0].id == "windows-wrapper"
+
+    (tmp_path / ".config/systemd/user").mkdir(parents=True)
+    (tmp_path / ".config/systemd/user/prompt-automation.service").touch()
+    system_unit = Path("/etc/systemd/system/prompt-automation.service")
+    system_unit.parent.mkdir(parents=True, exist_ok=True)
+    system_unit.touch()
+    try:
+        sysd_arts = detectors.detect_systemd_units(platform="linux")
+        assert {a.id for a in sysd_arts} == {"systemd-user", "systemd-system"}
+    finally:
+        try:
+            system_unit.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def test_action_ordering(tmp_path, monkeypatch):
+    a_path = tmp_path / "a.txt"
+    b_path = tmp_path / "b.txt"
+    a_path.write_text("a")
+    b_path.write_text("b")
+    art_a = Artifact("a", "file", a_path)
+    art_b = Artifact("b", "file", b_path)
+
+    def det_a(_platform):
+        return [art_a]
+
+    def det_b(_platform):
+        return [art_b]
+
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [det_a, det_b])
+    opts = UninstallOptions(force=True)
+    code, results = executor.run(opts)
+    assert code == 0
+    assert [r["id"] for r in results["removed"]] == ["a", "b"]
+    assert not a_path.exists() and not b_path.exists()


### PR DESCRIPTION
## Summary
- test artifact detection for data dirs, Windows wrappers and systemd units
- ensure uninstall executor processes artifacts in defined order
- exercise CLI uninstall flow for dry-run, purge-data, JSON output and idempotency

## Testing
- `pytest tests/test_uninstall_plan.py tests/test_uninstall_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c17a14393c83288b6214198bddde0e