### PR TITLE
Support uninstall across multiple Python interpreters

### DIFF
--- a/src/prompt_automation/uninstall/artifacts.py
+++ b/src/prompt_automation/uninstall/artifacts.py
@@ -16,6 +16,7 @@ class Artifact:
     requires_privilege: bool = False
     purge_candidate: bool = False
     repo_protected: bool = False
+    interpreter: Path | None = None
 
     def present(self) -> bool:
         """Return ``True`` if the artifact exists on disk."""

--- a/src/prompt_automation/uninstall/multi_python.py
+++ b/src/prompt_automation/uninstall/multi_python.py
@@ -1,0 +1,63 @@
+"""Helpers for interacting with multiple Python interpreters during uninstall."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import subprocess
+import sys
+from typing import Iterable, Tuple, List
+
+
+def enumerate_pythons() -> list[Path]:
+    """Return a list of available Python interpreter executables."""
+    seen: set[Path] = set()
+    executables: list[Path] = []
+    # include current interpreter first
+    current = Path(sys.executable).resolve()
+    seen.add(current)
+    executables.append(current)
+
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        try:
+            for name in os.listdir(directory):
+                if not name.startswith("python"):
+                    continue
+                candidate = Path(directory) / name
+                if not candidate.is_file():
+                    continue
+                try:
+                    st = candidate.stat()
+                    if not os.access(str(candidate), os.X_OK):
+                        continue
+                except OSError:
+                    continue
+                resolved = candidate.resolve()
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                executables.append(resolved)
+        except (OSError, FileNotFoundError):
+            continue
+    return executables
+
+
+def uninstall(interpreter: Path) -> tuple[bool, str]:
+    """Run pip uninstall for ``prompt-automation`` using the given interpreter.
+
+    Returns a tuple ``(success, output)`` where ``success`` indicates
+    whether the command completed successfully and ``output`` contains
+    combined stdout/stderr text.
+    """
+    try:
+        proc = subprocess.run(
+            [str(interpreter), "-m", "pip", "uninstall", "-y", "prompt-automation"],
+            capture_output=True,
+            text=True,
+        )
+        output = proc.stdout + proc.stderr
+        return proc.returncode == 0, output
+    except Exception as exc:  # pragma: no cover - defensive
+        return False, str(exc)

--- a/tests/uninstall/test_uninstall_multi_python.py
+++ b/tests/uninstall/test_uninstall_multi_python.py
@@ -1,0 +1,94 @@
+import subprocess
+from pathlib import Path
+import sys
+import json
+
+import pytest
+
+
+def _find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / "pyproject.toml").exists():
+            return d
+    return start.parent
+
+
+_repo_root = _find_repo_root(Path(__file__).resolve())
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from prompt_automation.uninstall import detectors, executor, multi_python  # noqa: E402
+from prompt_automation.uninstall.artifacts import Artifact  # noqa: E402
+from prompt_automation.cli.controller import UninstallOptions  # noqa: E402
+
+
+def test_detect_pip_install_records_interpreters(monkeypatch, tmp_path):
+    py1 = tmp_path / "py1"
+    py2 = tmp_path / "py2"
+    pkg1 = tmp_path / "pkg1"
+    pkg2 = tmp_path / "pkg2"
+    pkg1.mkdir()
+    pkg2.mkdir()
+    monkeypatch.setattr(multi_python, "enumerate_pythons", lambda: [py1, py2])
+
+    out1 = json.dumps({"location": str(pkg1), "requires_priv": False})
+    out2 = json.dumps({"location": str(pkg2), "requires_priv": True})
+
+    def fake_run(cmd, capture_output=True, text=True):
+        if cmd[0] == str(py1):
+            return subprocess.CompletedProcess(cmd, 0, stdout=out1, stderr="")
+        elif cmd[0] == str(py2):
+            return subprocess.CompletedProcess(cmd, 0, stdout=out2, stderr="")
+        raise AssertionError("unexpected interpreter")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    artifacts = detectors.detect_pip_install()
+    assert {a.interpreter for a in artifacts} == {py1, py2}
+    assert {a.requires_privilege for a in artifacts} == {False, True}
+
+
+def test_executor_uninstalls_each_interpreter(monkeypatch, tmp_path):
+    py1 = tmp_path / "py1"
+    py2 = tmp_path / "py2"
+    pkg1 = tmp_path / "pkg1"
+    pkg2 = tmp_path / "pkg2"
+    pkg1.mkdir()
+    pkg2.mkdir()
+    art1 = Artifact("pip1", "pip", pkg1, interpreter=py1)
+    art2 = Artifact("pip2", "pip", pkg2, interpreter=py2)
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _p: [art1, art2]])
+
+    calls = []
+    mapping = {py1: pkg1, py2: pkg2}
+
+    def fake_uninstall(interpreter):
+        calls.append(interpreter)
+        mapping[interpreter].rmdir()
+        return True, ""
+
+    monkeypatch.setattr(multi_python, "uninstall", fake_uninstall)
+    options = UninstallOptions(force=True)
+    code, results = executor.run(options)
+    assert code == 0
+    assert set(calls) == {py1, py2}
+    assert results["partial"] is False
+    assert {entry["interpreter"] for entry in results["removed"]} == {str(py1), str(py2)}
+
+
+def test_executor_reports_failures(monkeypatch, tmp_path):
+    py = tmp_path / "py"
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    art = Artifact("pip", "pip", pkg, interpreter=py)
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _p: [art]])
+
+    def fail_uninstall(interpreter):
+        return False, "boom"
+
+    monkeypatch.setattr(multi_python, "uninstall", fail_uninstall)
+    options = UninstallOptions(force=True)
+    code, results = executor.run(options)
+    assert code == 2
+    assert results["errors"][0]["interpreter"] == str(py)
+    assert results["errors"][0]["status"] == "failed"


### PR DESCRIPTION
## Summary
- Handle uninstalling `prompt-automation` for every Python interpreter found on PATH
- Detect pip installations with associated interpreters and run pip uninstall per interpreter
- Record interpreter-specific results and add coverage for success and failure cases

## Testing
- `pytest tests/uninstall/test_uninstall_multi_python.py -q`
- `pytest -q` *(fails: fast-path eval took 130.24ms (>75ms))*

------
https://chatgpt.com/codex/tasks/task_e_68c1b4ccb6948328a566c32c7951f4b8