### PR TITLE
Respect --all flag for uninstall optional artifacts

### DIFF
--- a/src/prompt_automation/uninstall/executor.py
+++ b/src/prompt_automation/uninstall/executor.py
@@ -16,9 +16,15 @@ from . import detectors, multi_python
 from ..errorlog import get_logger
 
 
+# Detectors used for core uninstall operations. Optional detectors that remove
+# ancillary artifacts are enabled when the ``--all`` flag is provided.
 _DEF_DETECTORS: Iterable = (
     detectors.detect_pip_install,
     detectors.detect_editable_repo,
+)
+
+# Extended detector set enabled by ``--all``.
+_OPT_DETECTORS: Iterable = (
     detectors.detect_espanso_package,
     detectors.detect_systemd_units,
     detectors.detect_desktop_entries,
@@ -75,7 +81,10 @@ def run(options: "UninstallOptions") -> tuple[int, dict[str, object]]:
     _log.debug("starting uninstall on platform=%s", platform)
     artifacts: list[Artifact] = []
     if not arg_error:
-        for func in _DEF_DETECTORS:
+        detector_funcs = list(_DEF_DETECTORS)
+        if options.all:
+            detector_funcs.extend(_OPT_DETECTORS)
+        for func in detector_funcs:
             try:
                 detected = func(platform)
                 artifacts.extend(detected)

--- a/tests/uninstall/test_executor.py
+++ b/tests/uninstall/test_executor.py
@@ -26,6 +26,7 @@ import json
 @pytest.fixture(autouse=True)
 def clear_detectors(monkeypatch):
     monkeypatch.setattr(executor, "_DEF_DETECTORS", [])
+    monkeypatch.setattr(executor, "_OPT_DETECTORS", [])
 
 
 def _make_artifact(tmp_path: Path) -> Artifact:

--- a/tests/uninstall/test_uninstall_all_flag.py
+++ b/tests/uninstall/test_uninstall_all_flag.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / "pyproject.toml").exists():
+            return d
+    return start.parent
+
+
+_repo_root = _find_repo_root(Path(__file__).resolve())
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from prompt_automation.cli.controller import UninstallOptions
+from prompt_automation.uninstall import executor
+from prompt_automation.uninstall.artifacts import Artifact
+
+
+def _make_artifact(tmp_path: Path, name: str) -> Artifact:
+    path = tmp_path / f"{name}.txt"
+    path.write_text("data")
+    return Artifact(name, "file", path)
+
+
+def test_all_flag_adds_optional_detectors(monkeypatch, tmp_path):
+    base = _make_artifact(tmp_path, "base")
+    extra = _make_artifact(tmp_path, "extra")
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _p: [base]])
+    monkeypatch.setattr(executor, "_OPT_DETECTORS", [lambda _p: [extra]])
+
+    # Without --all, optional detector should not run
+    opts = UninstallOptions(force=True)
+    code, results = executor.run(opts)
+    assert code == 0
+    assert not base.path.exists()
+    assert extra.path.exists()
+    assert {r["id"] for r in results["removed"]} == {"base"}
+
+    # With --all, optional detector is included
+    base2 = _make_artifact(tmp_path, "base2")
+    extra2 = _make_artifact(tmp_path, "extra2")
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _p: [base2]])
+    monkeypatch.setattr(executor, "_OPT_DETECTORS", [lambda _p: [extra2]])
+
+    opts_all = UninstallOptions(force=True, all=True)
+    code2, results2 = executor.run(opts_all)
+    assert code2 == 0
+    assert not base2.path.exists()
+    assert not extra2.path.exists()
+    assert {r["id"] for r in results2["removed"]} == {"base2", "extra2"}


### PR DESCRIPTION
## Summary
- Split uninstall detectors into core and optional sets
- Include optional artifact detectors only when `--all` is provided
- Add tests verifying `--all` enables extended removal set

## Testing
- `pytest -q` *(fails: fast-path eval took 76ms (>75ms))*


------
https://chatgpt.com/codex/tasks/task_e_68c1b697703483289f932245db7e8ca3