### PR TITLE
Add elevated uninstall script generation

### DIFF
--- a/docs/UNINSTALL.md
+++ b/docs/UNINSTALL.md
@@ -27,6 +27,7 @@ command, run with ``UNINSTALL_FEATURE_FLAG=0``.
 - `--verbose` – increase output verbosity
 - `--json` – emit a JSON summary of results
 - `--platform PLATFORM` – override the target platform for testing
+- `--print-elevated-script` – print a script to remove privileged artifacts
 
 ## Behavior
 
@@ -37,6 +38,11 @@ a confirmation is requested before removing each artifact. When purging data,
 files are backed up to `~/.config/prompt-automation.backup.<timestamp>` unless
 `--no-backup` is provided. The `--dry-run` flag prints the planned actions
 without making changes.
+
+When run without elevated privileges, any artifact that requires
+administrative access is skipped and recorded. Use `--print-elevated-script` to
+generate a shell (or PowerShell on Windows) script that removes those paths
+with the necessary permissions.
 
 ## Exit Codes
 

--- a/src/prompt_automation/cli/controller.py
+++ b/src/prompt_automation/cli/controller.py
@@ -51,6 +51,7 @@ class UninstallOptions:
     platform: str | None = None
     remove_orphans: bool = False
     confirm_orphans: bool = False
+    print_elevated_script: bool = False
 
 
 class PromptCLI:
@@ -250,6 +251,11 @@ class PromptCLI:
         uninstall.add_argument("--json", action="store_true", help="Emit JSON output")
         uninstall.add_argument("--platform", help="Target platform override")
         uninstall.add_argument(
+            "--print-elevated-script",
+            action="store_true",
+            help="Emit a script to remove artifacts requiring elevated privileges",
+        )
+        uninstall.add_argument(
             "--remove-orphans",
             action="store_true",
             help="Remove orphan prompt-automation executables",
@@ -280,6 +286,7 @@ class PromptCLI:
                 platform=args.platform,
                 remove_orphans=args.remove_orphans,
                 confirm_orphans=args.confirm_orphans,
+                print_elevated_script=args.print_elevated_script,
             )
             return run_uninstall(options)
 

--- a/tests/uninstall/test_executor.py
+++ b/tests/uninstall/test_executor.py
@@ -115,7 +115,7 @@ def test_idempotent_runs(monkeypatch, tmp_path):
 
     code2, results2 = executor.run(options)
     assert code2 == 0
-    assert results2 == {"removed": [], "skipped": [], "errors": [], "partial": False}
+    assert results2 == {"removed": [], "skipped": [], "errors": [], "partial": False, "pending": []}
 
 
 def test_json_output(monkeypatch, tmp_path, capsys):

--- a/tests/uninstall/test_uninstall_privileged_plan.py
+++ b/tests/uninstall/test_uninstall_privileged_plan.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    for d in [start] + list(start.parents):
+        if (d / "pyproject.toml").exists():
+            return d
+    return start.parent
+
+
+_repo_root = _find_repo_root(Path(__file__).resolve())
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from prompt_automation.uninstall import executor
+from prompt_automation.uninstall.artifacts import Artifact
+from prompt_automation.cli.controller import UninstallOptions
+
+
+def _make_priv_art(tmp_path: Path) -> Artifact:
+    path = tmp_path / "sysfile.txt"
+    path.write_text("data")
+    return Artifact("sysfile", "file", path, requires_privilege=True)
+
+
+def test_print_script_posix(monkeypatch, tmp_path, capsys):
+    art = _make_priv_art(tmp_path)
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _platform: [art]])
+    monkeypatch.setattr(executor.os, "geteuid", lambda: 1000)
+    opts = UninstallOptions(force=True, print_elevated_script=True)
+    code, results = executor.run(opts)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert results["pending"] == [str(art.path)]
+    assert f"rm -rf '{art.path}'" in out
+
+
+def test_print_script_windows(monkeypatch, tmp_path, capsys):
+    art = _make_priv_art(tmp_path)
+    monkeypatch.setattr(executor, "_DEF_DETECTORS", [lambda _platform: [art]])
+    monkeypatch.setattr(executor.os, "geteuid", lambda: 1000)
+    opts = UninstallOptions(force=True, print_elevated_script=True, platform="win32")
+    code, results = executor.run(opts)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert results["pending"] == [str(art.path)]
+    assert f'Remove-Item -Recurse -Force "{art.path}"' in out


### PR DESCRIPTION
## Summary
- track privileged uninstall artifacts and capture pending paths
- add `--print-elevated-script` option to emit removal script
- document elevated uninstall workflow and add tests

## Testing
- `pytest tests/uninstall/test_executor.py tests/uninstall/test_uninstall_privileged_plan.py`
- `pytest` *(fails: fast-path eval took 116.96ms (>75ms))*

------
https://chatgpt.com/codex/tasks/task_e_68c1c09e26e4832899d18b864c522c5d